### PR TITLE
Add conditional compilation for specific protocols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,17 @@ keywords = ["server", "query", "game", "check", "status"]
 rust-version = "1.56.1"
 
 [features]
-default = []
-no_games = []
-no_services = []
+default = ["protocol_all", "service_all"]
+games = []
+protocol_valve = ["games"]
+protocol_minecraft = ["games"]
+protocol_gamespy = ["games"]
+protocol_all = ["protocol_valve", "protocol_minecraft", "protocol_gamespy"]
+
+services = []
+service_valve = ["services"]
+service_all = ["service_valve"]
+
 serde = ["dep:serde", "serde/derive"]
 
 [dependencies]

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -1,96 +1,143 @@
 //! Currently supported games.
 
 /// Alien Swarm
+#[cfg(feature = "protocol_valve")]
 pub mod aliens;
 /// Age of Chivalry
+#[cfg(feature = "protocol_valve")]
 pub mod aoc;
 /// ARMA 2: Operation Arrowhead
+#[cfg(feature = "protocol_valve")]
 pub mod arma2oa;
 /// ARK: Survival Evolved
+#[cfg(feature = "protocol_valve")]
 pub mod ase;
 /// Alien Swarm: Reactive Drop
+#[cfg(feature = "protocol_valve")]
 pub mod asrd;
 /// Avorion
+#[cfg(feature = "protocol_valve")]
 pub mod avorion;
 /// Battalion 1944
+#[cfg(feature = "protocol_valve")]
 pub mod bat1944;
 /// BrainBread 2
+#[cfg(feature = "protocol_valve")]
 pub mod bb2;
 /// Battlefield 1942
+#[cfg(feature = "protocol_gamespy")]
 pub mod bf1942;
 /// Black Mesa
+#[cfg(feature = "protocol_valve")]
 pub mod bm;
 /// Ballistic Overkill
+#[cfg(feature = "protocol_valve")]
 pub mod bo;
 /// Codename CURE
+#[cfg(feature = "protocol_valve")]
 pub mod ccure;
 /// Colony Survival
+#[cfg(feature = "protocol_valve")]
 pub mod cosu;
 /// Counter-Strike
+#[cfg(feature = "protocol_valve")]
 pub mod cs;
 /// Counter Strike: Condition Zero
+#[cfg(feature = "protocol_valve")]
 pub mod cscz;
 /// Counter-Strike: Global Offensive
+#[cfg(feature = "protocol_valve")]
 pub mod csgo;
 /// Counter-Strike: Source
+#[cfg(feature = "protocol_valve")]
 pub mod css;
+/// Crysis Wars
+#[cfg(feature = "protocol_gamespy")]
+pub mod cw;
 /// Day of Defeat
+#[cfg(feature = "protocol_valve")]
 pub mod dod;
 /// Day of Defeat: Source
+#[cfg(feature = "protocol_valve")]
 pub mod dods;
 /// Day of Infamy
+#[cfg(feature = "protocol_valve")]
 pub mod doi;
 /// Don't Starve Together
+#[cfg(feature = "protocol_valve")]
 pub mod dst;
 /// Frontlines: Fuel of War
+#[cfg(feature = "protocol_valve")]
 pub mod ffow;
 /// Garry's Mod
+#[cfg(feature = "protocol_valve")]
 pub mod gm;
 /// Half-Life 2 Deathmatch
+#[cfg(feature = "protocol_valve")]
 pub mod hl2dm;
 /// Half-Life Deathmatch: Source
+#[cfg(feature = "protocol_valve")]
 pub mod hldms;
 /// Insurgency
+#[cfg(feature = "protocol_valve")]
 pub mod ins;
 /// Insurgency: Modern Infantry Combat
+#[cfg(feature = "protocol_valve")]
 pub mod insmic;
 /// Insurgency: Sandstorm
+#[cfg(feature = "protocol_valve")]
 pub mod inss;
 /// Left 4 Dead
+#[cfg(feature = "protocol_valve")]
 pub mod l4d;
 /// Left 4 Dead 2
+#[cfg(feature = "protocol_valve")]
 pub mod l4d2;
 /// Minecraft
+#[cfg(feature = "protocol_minecraft")]
 pub mod mc;
 /// Operation: Harsh Doorstop
+#[cfg(feature = "protocol_valve")]
 pub mod ohd;
 /// Onset
+#[cfg(feature = "protocol_valve")]
 pub mod onset;
 /// Project Zomboid
+#[cfg(feature = "protocol_valve")]
 pub mod pz;
 /// Risk of Rain 2
+#[cfg(feature = "protocol_valve")]
 pub mod ror2;
 /// Rust
+#[cfg(feature = "protocol_valve")]
 pub mod rust;
 /// Sven Co-op
+#[cfg(feature = "protocol_valve")]
 pub mod sc;
 /// 7 Days To Die
+#[cfg(feature = "protocol_valve")]
 pub mod sdtd;
 /// Serious Sam
+#[cfg(feature = "protocol_gamespy")]
 pub mod ss;
 /// The Forest
+#[cfg(feature = "protocol_valve")]
 pub mod tf;
 /// Team Fortress 2
+#[cfg(feature = "protocol_valve")]
 pub mod tf2;
 /// Team Fortress Classic
+#[cfg(feature = "protocol_valve")]
 pub mod tfc;
 /// The Ship
+#[cfg(feature = "protocol_valve")]
 pub mod ts;
 /// Unturned
+#[cfg(feature = "protocol_valve")]
 pub mod unturned;
 /// Unreal Tournament
+#[cfg(feature = "protocol_gamespy")]
 pub mod ut;
 /// V Rising
+#[cfg(feature = "protocol_valve")]
 pub mod vr;
-/// Crysis Wars
-pub mod cw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,21 @@
 //! ```
 //!
 //! # Crate features:
-//! Enabled by default: None
+//! Enabled by default: `protocols_all`, `services_all`
 //!
 //! `serde` - enables json serialization/deserialization for all response types. <br>
-//! `no_games` - disables the included games support. <br>
-//! `no_services` - disables the included services support.
+//! `protocol_all` - Enables all protocols. <br>
+//! `service_all` - Enables all services. <br><br>
+//! `protocol_valve` - Enables valve query protocol.<br>
+//! `protocol_gamespy` - Enable gamespy protocol.<br>
+//! `protocol_minecraft` - Enable minecraft protocol.<br><br>
+//! `service_valve` - Enable valve master server protocol.
 
 pub mod errors;
-#[cfg(not(feature = "no_games"))]
+#[cfg(feature = "games")]
 pub mod games;
 pub mod protocols;
-#[cfg(not(feature = "no_services"))]
+#[cfg(feature = "services")]
 pub mod services;
 
 mod bufferer;
@@ -31,7 +35,7 @@ mod socket;
 mod utils;
 
 pub use errors::*;
-#[cfg(not(feature = "no_games"))]
+#[cfg(feature = "games")]
 pub use games::*;
-#[cfg(not(feature = "no_services"))]
+#[cfg(feature = "services")]
 pub use services::*;

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -5,10 +5,13 @@
 //! independently queried.
 
 /// Reference: [node-GameDig](https://github.com/gamedig/node-gamedig/blob/master/protocols/gamespy1.js)
+#[cfg(feature="protocol_gamespy")]
 pub mod gamespy;
 /// Reference: [Server List Ping](https://wiki.vg/Server_List_Ping)
+#[cfg(feature="protocol_minecraft")]
 pub mod minecraft;
 /// General types that are used by all protocols.
 pub mod types;
 /// Reference: [Server Query](https://developer.valvesoftware.com/wiki/Server_queries)
+#[cfg(feature="protocol_valve")]
 pub mod valve;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 //! Services that are currently implemented.
 
 /// Reference: [Master Server Query Protocol](https://developer.valvesoftware.com/wiki/Master_Server_Query_Protocol)
+#[cfg(feature="service_valve")]
 pub mod valve_master_server;


### PR DESCRIPTION
This allows for conditional compilation at protocol level (although most games are valve anyway :^) ). Changes the behaviour from enabling `disable_x` feature to disable either services or all protocols to being able to enable specific services and protocols. All protocols and services are put in default so in order to only include a subset `default-features=false` must be used.

Closes #38 