### PR TITLE
Enable the use of Ipv6 addresses

### DIFF
--- a/examples/master_querant.rs
+++ b/examples/master_querant.rs
@@ -4,7 +4,7 @@ use gamedig::protocols::valve;
 use gamedig::protocols::valve::Engine;
 use gamedig::{aliens, aoc, arma2oa, ase, asrd, avorion, bat1944, bb2, bf1942, bm, bo, ccure, cosu, cs, cscz, csgo, css, dod, dods, doi, dst, ffow, gm, hl2dm, hldms, ins, insmic, inss, l4d, l4d2, mc, ohd, onset, pz, ror2, rust, sc, sdtd, ss, tf, tf2, tfc, ts, unturned, ut, vr, GDResult, cw};
 use std::env;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 fn main() -> GDResult<()> {
     let args: Vec<String> = env::args().collect();
@@ -20,7 +20,7 @@ fn main() -> GDResult<()> {
         return Ok(());
     }
 
-    let ip = &args[2].as_str().parse::<Ipv4Addr>().unwrap();
+    let ip = &args[2].as_str().parse::<IpAddr>().unwrap();
     let port = match args.len() == 4 {
         false => {
             if args[1].starts_with("_") {

--- a/src/games/aliens.rs
+++ b/src/games/aliens.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/aoc.rs
+++ b/src/games/aoc.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/arma2oa.rs
+++ b/src/games/arma2oa.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(2304),

--- a/src/games/ase.rs
+++ b/src/games/ase.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/asrd.rs
+++ b/src/games/asrd.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/avorion.rs
+++ b/src/games/avorion.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27020),

--- a/src/games/bat1944.rs
+++ b/src/games/bat1944.rs
@@ -1,11 +1,11 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDError::TypeParse,
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let mut valve_response = valve::query(
         address,
         port.unwrap_or(7780),

--- a/src/games/bb2.rs
+++ b/src/games/bb2.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/bf1942.rs
+++ b/src/games/bf1942.rs
@@ -1,8 +1,8 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::protocols::gamespy;
 use crate::protocols::gamespy::one::Response;
 use crate::GDResult;
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
     gamespy::one::query(address, port.unwrap_or(23000), None)
 }

--- a/src/games/bm.rs
+++ b/src/games/bm.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/bo.rs
+++ b/src/games/bo.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27016),

--- a/src/games/ccure.rs
+++ b/src/games/ccure.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/cosu.rs
+++ b/src/games/cosu.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27004),

--- a/src/games/cs.rs
+++ b/src/games/cs.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/cscz.rs
+++ b/src/games/cscz.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/csgo.rs
+++ b/src/games/csgo.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/css.rs
+++ b/src/games/css.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/cw.rs
+++ b/src/games/cw.rs
@@ -1,8 +1,8 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::protocols::gamespy;
 use crate::protocols::gamespy::three::Response;
 use crate::GDResult;
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
     gamespy::three::query(address, port.unwrap_or(64100), None)
 }

--- a/src/games/dod.rs
+++ b/src/games/dod.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/dods.rs
+++ b/src/games/dods.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/doi.rs
+++ b/src/games/doi.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/dst.rs
+++ b/src/games/dst.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27016),

--- a/src/games/ffow.rs
+++ b/src/games/ffow.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::protocols::types::TimeoutSettings;
 use crate::protocols::valve::{Engine, Environment, Server, ValveProtocol};
 use crate::GDResult;
@@ -43,11 +43,11 @@ pub struct Response {
     pub time_left: u16,
 }
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
     query_with_timeout(address, port, TimeoutSettings::default())
 }
 
-pub fn query_with_timeout(address: &Ipv4Addr, port: Option<u16>, timeout_settings: TimeoutSettings) -> GDResult<Response> {
+pub fn query_with_timeout(address: &IpAddr, port: Option<u16>, timeout_settings: TimeoutSettings) -> GDResult<Response> {
     let mut client = ValveProtocol::new(address, port.unwrap_or(5478), Some(timeout_settings))?;
     let mut buffer = client.get_request_data(
         &Engine::GoldSrc(true),

--- a/src/games/gm.rs
+++ b/src/games/gm.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27016),

--- a/src/games/hl2dm.rs
+++ b/src/games/hl2dm.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/hldms.rs
+++ b/src/games/hldms.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/ins.rs
+++ b/src/games/ins.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/insmic.rs
+++ b/src/games/insmic.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/inss.rs
+++ b/src/games/inss.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27131),

--- a/src/games/l4d.rs
+++ b/src/games/l4d.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/l4d2.rs
+++ b/src/games/l4d2.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/mc.rs
+++ b/src/games/mc.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::minecraft::{self, BedrockResponse, JavaResponse, LegacyGroup},
     GDError,
@@ -7,7 +7,7 @@ use crate::{
 
 /// Query with all the protocol variants one by one (Java -> Bedrock -> Legacy
 /// (1.6 -> 1.4 -> Beta 1.8)).
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<JavaResponse> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
     if let Ok(response) = query_java(address, port) {
         return Ok(response);
     }
@@ -24,22 +24,22 @@ pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<JavaResponse> {
 }
 
 /// Query a Java Server.
-pub fn query_java(address: &Ipv4Addr, port: Option<u16>) -> GDResult<JavaResponse> {
+pub fn query_java(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
     minecraft::query_java(address, port_or_java_default(port), None)
 }
 
 /// Query a (Java) Legacy Server (1.6 -> 1.4 -> Beta 1.8).
-pub fn query_legacy(address: &Ipv4Addr, port: Option<u16>) -> GDResult<JavaResponse> {
+pub fn query_legacy(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
     minecraft::query_legacy(address, port_or_java_default(port), None)
 }
 
 /// Query a specific (Java) Legacy Server.
-pub fn query_legacy_specific(group: LegacyGroup, address: &Ipv4Addr, port: Option<u16>) -> GDResult<JavaResponse> {
+pub fn query_legacy_specific(group: LegacyGroup, address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
     minecraft::query_legacy_specific(group, address, port_or_java_default(port), None)
 }
 
 /// Query a Bedrock Server.
-pub fn query_bedrock(address: &Ipv4Addr, port: Option<u16>) -> GDResult<BedrockResponse> {
+pub fn query_bedrock(address: &IpAddr, port: Option<u16>) -> GDResult<BedrockResponse> {
     minecraft::query_bedrock(address, port_or_bedrock_default(port), None)
 }
 

--- a/src/games/ohd.rs
+++ b/src/games/ohd.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27005),

--- a/src/games/onset.rs
+++ b/src/games/onset.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(7776),

--- a/src/games/pz.rs
+++ b/src/games/pz.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(16261),

--- a/src/games/ror2.rs
+++ b/src/games/ror2.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27016),

--- a/src/games/rust.rs
+++ b/src/games/rust.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/sc.rs
+++ b/src/games/sc.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/sdtd.rs
+++ b/src/games/sdtd.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(26900),

--- a/src/games/ss.rs
+++ b/src/games/ss.rs
@@ -1,8 +1,8 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::protocols::gamespy;
 use crate::protocols::gamespy::one::Response;
 use crate::GDResult;
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
     gamespy::one::query(address, port.unwrap_or(25601), None)
 }

--- a/src/games/tf.rs
+++ b/src/games/tf.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27016),

--- a/src/games/tf2.rs
+++ b/src/games/tf2.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/tfc.rs
+++ b/src/games/tfc.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/ts.rs
+++ b/src/games/ts.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, get_optional_extracted_data, Server, ServerPlayer, SteamApp},
     GDResult,
@@ -94,7 +94,7 @@ impl Response {
     }
 }
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/unturned.rs
+++ b/src/games/unturned.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27015),

--- a/src/games/ut.rs
+++ b/src/games/ut.rs
@@ -1,8 +1,8 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::protocols::gamespy;
 use crate::protocols::gamespy::one::Response;
 use crate::GDResult;
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
     gamespy::one::query(address, port.unwrap_or(7778), None)
 }

--- a/src/games/vr.rs
+++ b/src/games/vr.rs
@@ -1,10 +1,10 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::valve::{self, game, SteamApp},
     GDResult,
 };
 
-pub fn query(address: &Ipv4Addr, port: Option<u16>) -> GDResult<game::Response> {
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
     let valve_response = valve::query(
         address,
         port.unwrap_or(27016),

--- a/src/protocols/gamespy/protocols/one/protocol.rs
+++ b/src/protocols/gamespy/protocols/one/protocol.rs
@@ -11,10 +11,10 @@ use crate::{
 
 use crate::protocols::gamespy::common::has_password;
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 fn get_server_values(
-    address: &Ipv4Addr,
+    address: &IpAddr,
     port: u16,
     timeout_settings: Option<TimeoutSettings>,
 ) -> GDResult<HashMap<String, String>> {
@@ -178,7 +178,7 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
 /// If there are parsing problems using the `query` function, you can directly
 /// get the server's values using this function.
 pub fn query_vars(
-    address: &Ipv4Addr,
+    address: &IpAddr,
     port: u16,
     timeout_settings: Option<TimeoutSettings>,
 ) -> GDResult<HashMap<String, String>> {
@@ -188,7 +188,7 @@ pub fn query_vars(
 /// Query a server by providing the address, the port and timeout settings.
 /// Providing None to the timeout settings results in using the default values.
 /// (TimeoutSettings::[default](TimeoutSettings::default)).
-pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Response> {
     let mut server_vars = query_vars(address, port, timeout_settings)?;
 
     let players_maximum = server_vars

--- a/src/protocols/gamespy/protocols/three/protocol.rs
+++ b/src/protocols/gamespy/protocols/three/protocol.rs
@@ -5,7 +5,7 @@ use crate::protocols::types::TimeoutSettings;
 use crate::socket::{Socket, UdpSocket};
 use crate::{GDError, GDResult};
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 const THIS_SESSION_ID: u32 = 1;
 
@@ -43,7 +43,7 @@ struct GameSpy3 {
 const PACKET_SIZE: usize = 2048;
 
 impl GameSpy3 {
-    fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = UdpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -104,7 +104,7 @@ impl GameSpy3 {
     }
 }
 
-fn get_server_packets(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Vec<Vec<u8>>> {
+fn get_server_packets(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Vec<Vec<u8>>> {
     let mut gs3 = GameSpy3::new(address, port, timeout_settings)?;
 
     let challenge = gs3.make_initial_handshake()?;
@@ -165,7 +165,7 @@ fn data_to_map(packet: &[u8]) -> GDResult<(HashMap<String, String>, Vec<u8>)> {
 /// If there are parsing problems using the `query` function, you can directly
 /// get the server's values using this function.
 pub fn query_vars(
-    address: &Ipv4Addr,
+    address: &IpAddr,
     port: u16,
     timeout_settings: Option<TimeoutSettings>,
 ) -> GDResult<HashMap<String, String>> {
@@ -308,7 +308,7 @@ fn parse_players_and_teams(packets: Vec<Vec<u8>>) -> GDResult<(Vec<Player>, Vec<
 /// Query a server by providing the address, the port and timeout settings.
 /// Providing None to the timeout settings results in using the default values.
 /// (TimeoutSettings::[default](TimeoutSettings::default)).
-pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Response> {
+pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Response> {
     let packets = get_server_packets(address, port, timeout_settings)?;
 
     let (mut server_vars, remaining_data) = data_to_map(packets.get(0).ok_or(GDError::PacketBad)?)?;

--- a/src/protocols/minecraft/protocol/bedrock.rs
+++ b/src/protocols/minecraft/protocol/bedrock.rs
@@ -1,7 +1,7 @@
 // This file has code that has been documented by the NodeJS GameDig library
 // (MIT) from https://github.com/gamedig/node-gamedig/blob/master/protocols/minecraftbedrock.js
 
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     bufferer::{Bufferer, Endianess},
     protocols::{
@@ -19,7 +19,7 @@ pub struct Bedrock {
 }
 
 impl Bedrock {
-    fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = UdpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -93,7 +93,7 @@ impl Bedrock {
         })
     }
 
-    pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<BedrockResponse> {
+    pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<BedrockResponse> {
         Bedrock::new(address, port, timeout_settings)?.get_info()
     }
 }

--- a/src/protocols/minecraft/protocol/java.rs
+++ b/src/protocols/minecraft/protocol/java.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     bufferer::{Bufferer, Endianess},
     protocols::{
@@ -31,7 +31,7 @@ pub struct Java {
 }
 
 impl Java {
-    fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = TcpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -139,7 +139,7 @@ impl Java {
         })
     }
 
-    pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+    pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
         Java::new(address, port, timeout_settings)?.get_info()
     }
 }

--- a/src/protocols/minecraft/protocol/legacy_bv1_8.rs
+++ b/src/protocols/minecraft/protocol/legacy_bv1_8.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     bufferer::{Bufferer, Endianess},
     protocols::{
@@ -16,7 +16,7 @@ pub struct LegacyBV1_8 {
 }
 
 impl LegacyBV1_8 {
-    fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = TcpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -60,7 +60,7 @@ impl LegacyBV1_8 {
         })
     }
 
-    pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+    pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
         LegacyBV1_8::new(address, port, timeout_settings)?.get_info()
     }
 }

--- a/src/protocols/minecraft/protocol/legacy_v1_4.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_4.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     bufferer::{Bufferer, Endianess},
     protocols::{
@@ -16,7 +16,7 @@ pub struct LegacyV1_4 {
 }
 
 impl LegacyV1_4 {
-    fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = TcpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -64,7 +64,7 @@ impl LegacyV1_4 {
         })
     }
 
-    pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+    pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
         LegacyV1_4::new(address, port, timeout_settings)?.get_info()
     }
 }

--- a/src/protocols/minecraft/protocol/legacy_v1_6.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_6.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     bufferer::{Bufferer, Endianess},
     protocols::{
@@ -16,7 +16,7 @@ pub struct LegacyV1_6 {
 }
 
 impl LegacyV1_6 {
-    fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = TcpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -93,7 +93,7 @@ impl LegacyV1_6 {
         LegacyV1_6::get_response(&mut buffer)
     }
 
-    pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+    pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
         LegacyV1_6::new(address, port, timeout_settings)?.get_info()
     }
 }

--- a/src/protocols/minecraft/protocol/mod.rs
+++ b/src/protocols/minecraft/protocol/mod.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use crate::{
     protocols::minecraft::{
         protocol::{
@@ -25,7 +25,7 @@ mod legacy_v1_6;
 
 /// Queries a Minecraft server with all the protocol variants one by one (Java
 /// -> Bedrock -> Legacy (1.6 -> 1.4 -> Beta 1.8)).
-pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+pub fn query(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
     if let Ok(response) = query_java(address, port, timeout_settings.clone()) {
         return Ok(response);
     }
@@ -42,12 +42,12 @@ pub fn query(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSett
 }
 
 /// Query a Java Server.
-pub fn query_java(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+pub fn query_java(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
     Java::query(address, port, timeout_settings)
 }
 
 /// Query a (Java) Legacy Server (1.6 -> 1.4 -> Beta 1.8).
-pub fn query_legacy(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
+pub fn query_legacy(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
     if let Ok(response) = query_legacy_specific(LegacyGroup::V1_6, address, port, timeout_settings.clone()) {
         return Ok(response);
     }
@@ -66,7 +66,7 @@ pub fn query_legacy(address: &Ipv4Addr, port: u16, timeout_settings: Option<Time
 /// Query a specific (Java) Legacy Server.
 pub fn query_legacy_specific(
     group: LegacyGroup,
-    address: &Ipv4Addr,
+    address: &IpAddr,
     port: u16,
     timeout_settings: Option<TimeoutSettings>,
 ) -> GDResult<JavaResponse> {
@@ -78,6 +78,6 @@ pub fn query_legacy_specific(
 }
 
 /// Query a Bedrock Server.
-pub fn query_bedrock(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<BedrockResponse> {
+pub fn query_bedrock(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<BedrockResponse> {
     Bedrock::query(address, port, timeout_settings)
 }

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -30,7 +30,7 @@ use bzip2_rs::decoder::Decoder;
 
 use crate::protocols::valve::Packet;
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 #[derive(Debug)]
 #[allow(dead_code)] //remove this later on
@@ -125,7 +125,7 @@ pub(crate) struct ValveProtocol {
 static PACKET_SIZE: usize = 6144;
 
 impl ValveProtocol {
-    pub fn new(address: &Ipv4Addr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
+    pub fn new(address: &IpAddr, port: u16, timeout_settings: Option<TimeoutSettings>) -> GDResult<Self> {
         let socket = UdpSocket::new(address, port)?;
         socket.apply_timeout(timeout_settings)?;
 
@@ -412,7 +412,7 @@ impl ValveProtocol {
 /// (GatherSettings::[default](GatheringSettings::default),
 /// TimeoutSettings::[default](TimeoutSettings::default)).
 pub fn query(
-    address: &Ipv4Addr,
+    address: &IpAddr,
     port: u16,
     engine: Engine,
     gather_settings: Option<GatheringSettings>,
@@ -429,7 +429,7 @@ pub fn query(
 }
 
 fn get_response(
-    address: &Ipv4Addr,
+    address: &IpAddr,
     port: u16,
     engine: Engine,
     gather_settings: GatheringSettings,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -9,12 +9,12 @@ use std::{
     io::{Read, Write},
     net,
 };
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 const DEFAULT_PACKET_SIZE: usize = 1024;
 
 pub trait Socket {
-    fn new(address: &Ipv4Addr, port: u16) -> GDResult<Self>
+    fn new(address: &IpAddr, port: u16) -> GDResult<Self>
     where Self: Sized;
 
     fn apply_timeout(&self, timeout_settings: Option<TimeoutSettings>) -> GDResult<()>;
@@ -28,7 +28,7 @@ pub struct TcpSocket {
 }
 
 impl Socket for TcpSocket {
-    fn new(address: &Ipv4Addr, port: u16) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16) -> GDResult<Self> {
         let complete_address = address_and_port_as_string(address, port);
 
         Ok(Self {
@@ -65,7 +65,7 @@ pub struct UdpSocket {
 }
 
 impl Socket for UdpSocket {
-    fn new(address: &Ipv4Addr, port: u16) -> GDResult<Self> {
+    fn new(address: &IpAddr, port: u16) -> GDResult<Self> {
         let complete_address = address_and_port_as_string(address, port);
         let socket = net::UdpSocket::bind("0.0.0.0:0").map_err(|_| SocketBind)?;
 
@@ -100,7 +100,6 @@ impl Socket for UdpSocket {
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
     use std::thread;
 
     use super::*;
@@ -117,10 +116,7 @@ mod tests {
             stream.write(&buf).unwrap();
         });
 
-        let address = match bound_address.ip() {
-            IpAddr::V4(a) => a,
-            _ => panic!("address not ipv4!")
-        };
+        let address = bound_address.ip();
 
         // Create a TCP socket and send a message to the server
         let mut socket = TcpSocket::new(&address, bound_address.port()).unwrap();
@@ -153,10 +149,7 @@ mod tests {
             socket.send_to(&buf, src_addr).unwrap();
         });
 
-        let address = match bound_address.ip() {
-            IpAddr::V4(a) => a,
-            _ => panic!("address not ipv4!")
-        };
+        let address = bound_address.ip();
 
         // Create a UDP socket and send a message to the server
         let mut socket = UdpSocket::new(&address, bound_address.port()).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use std::cmp::Ordering;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 
 pub fn error_by_expected_size(expected: usize, size: usize) -> GDResult<()> {
     match size.cmp(&expected) {
@@ -14,18 +14,18 @@ pub fn error_by_expected_size(expected: usize, size: usize) -> GDResult<()> {
     }
 }
 
-pub fn address_and_port_as_string(address: &Ipv4Addr, port: u16) -> String { format!("{}:{}", address, port) }
+pub fn address_and_port_as_string(address: &IpAddr, port: u16) -> String { format!("{}:{}", address, port) }
 
 pub fn u8_lower_upper(n: u8) -> (u8, u8) { (n & 15, n >> 4) }
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn address_and_port_as_string() {
         assert_eq!(
-            super::address_and_port_as_string(&Ipv4Addr::new(192, 168, 0, 1), 27015),
+            super::address_and_port_as_string(&IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 27015),
             "192.168.0.1:27015"
         );
     }


### PR DESCRIPTION
Replace usages of Ipv4Addr with IpAddr which allows the use of either Ipv4 or Ipv6.

This patch essentially consists of running:
"sed -i 's/Ipv4Addr/IpAddr/g' src/**/*.rs"
and fixing the errors.

Closes #39 