### PR TITLE
Programmatic games by storing information as data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ keywords = ["server", "query", "game", "check", "status"]
 rust-version = "1.60.0"
 
 [features]
-default = []
+default = ["game_defs"]
 no_games = []
 no_services = []
+game_defs = ["dep:phf"]
 serde = ["dep:serde", "serde/derive"]
 
 [dependencies]
@@ -29,3 +30,5 @@ crc32fast = "1.3.2"
 serde_json = "1.0.91"
 
 serde = { version = "1.0.155", optional = true }
+
+phf = { version = "0.11", optional = true, features = ["macros"] }

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -1,0 +1,61 @@
+use gamedig::{protocols::GenericResponse, query, GDResult, GAMES};
+
+use std::net::IpAddr;
+
+fn generic_query(game_name: &str, addr: &IpAddr, port: Option<u16>) -> GDResult<GenericResponse> {
+    let game = GAMES.get(game_name).expect("Game doesn't exist");
+
+    println!("Querying {:?} with {:?}", addr, game);
+
+    let response = query(game, addr, port)?;
+
+    println!("{:?}", response);
+
+    Ok(response)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+
+    let game_name = args.next().expect("Must provide a game name");
+    let addr: IpAddr = args
+        .next()
+        .map(|s| s.parse().unwrap())
+        .expect("Must provide address");
+    let port: Option<u16> = args.next().map(|s| s.parse().unwrap());
+
+    generic_query(&game_name, &addr, port).unwrap();
+}
+
+#[cfg(test)]
+mod test {
+    use gamedig::GAMES;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::generic_query;
+
+    const ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    fn test_game(game_name: &str) {
+        assert!(generic_query(game_name, &ADDR, None).is_err());
+    }
+
+    #[test]
+    fn battlefield() { test_game("bf1942"); }
+
+    #[test]
+    fn minecraft() { test_game("mc"); }
+
+    #[test]
+    fn tf2() { test_game("tf2"); }
+
+    #[test]
+    fn quake() { test_game("quake3a"); }
+
+    #[test]
+    fn all_games() {
+        for game_name in GAMES.keys() {
+            test_game(game_name);
+        }
+    }
+}

--- a/src/protocols/gamespy/mod.rs
+++ b/src/protocols/gamespy/mod.rs
@@ -3,3 +3,17 @@ mod common;
 pub mod protocols;
 
 pub use protocols::*;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum GameSpyVersion {
+    One,
+    Three,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResponseVersion {
+    One(protocols::one::Response),
+    Three(protocols::three::Response),
+}

--- a/src/protocols/gamespy/protocols/one/types.rs
+++ b/src/protocols/gamespy/protocols/one/types.rs
@@ -3,6 +3,11 @@ use std::collections::HashMap;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::protocols::{
+    gamespy::{GameSpyVersion, ResponseVersion},
+    GenericResponse,
+};
+
 /// A player’s details.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -38,4 +43,22 @@ pub struct Response {
     pub players: Vec<Player>,
     pub tournament: bool,
     pub unused_entries: HashMap<String, String>,
+}
+
+impl From<Response> for GenericResponse {
+    fn from(r: Response) -> Self {
+        let clone = r.clone();
+        Self {
+            server_name: Some(r.name),
+            server_description: None,
+            server_game: Some(r.game_type),
+            server_game_version: Some(r.game_version),
+            server_map: Some(r.map),
+            players_maximum: Some(r.players_maximum.try_into().unwrap()), // FIXME: usize to u64 may fail
+            players_online: Some(r.players_online.try_into().unwrap()),
+            players_bots: None,
+            has_password: Some(r.has_password),
+            inner: crate::protocols::SpecificResponse::Gamespy(ResponseVersion::One(clone)),
+        }
+    }
 }

--- a/src/protocols/gamespy/protocols/three/types.rs
+++ b/src/protocols/gamespy/protocols/three/types.rs
@@ -1,3 +1,4 @@
+use crate::protocols::{gamespy::ResponseVersion, GenericResponse};
 use std::collections::HashMap;
 
 #[cfg(feature = "serde")]
@@ -39,4 +40,22 @@ pub struct Response {
     pub teams: Vec<Team>,
     pub tournament: bool,
     pub unused_entries: HashMap<String, String>,
+}
+
+impl From<Response> for GenericResponse {
+    fn from(r: Response) -> Self {
+        let clone = r.clone();
+        Self {
+            server_name: Some(r.name),
+            server_description: None,
+            server_game: Some(r.game_type),
+            server_game_version: Some(r.game_version),
+            server_map: Some(r.map),
+            players_maximum: Some(r.players_maximum.try_into().unwrap()), // FIXME: usize to u64 may fail
+            players_online: Some(r.players_online.try_into().unwrap()),
+            players_bots: None,
+            has_password: Some(r.has_password),
+            inner: crate::protocols::SpecificResponse::Gamespy(ResponseVersion::Three(clone)),
+        }
+    }
 }

--- a/src/protocols/minecraft/protocol/mod.rs
+++ b/src/protocols/minecraft/protocol/mod.rs
@@ -23,6 +23,16 @@ mod legacy_bv1_8;
 mod legacy_v1_4;
 mod legacy_v1_6;
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum MinecraftVersion {
+    Bedrock,
+    Java,
+    LegacyBV1_8,
+    LegacyV1_4,
+    LegacyV1_6,
+}
+
 /// Queries a Minecraft server with all the protocol variants one by one (Java
 /// -> Bedrock -> Legacy (1.6 -> 1.4 -> Beta 1.8)).
 pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     bufferer::Bufferer,
+    protocols::GenericResponse,
     GDError::{PacketBad, UnknownEnumCast},
     GDResult,
 };
@@ -68,6 +69,24 @@ pub struct JavaResponse {
     pub enforces_secure_chat: Option<bool>,
     /// Tell's the server type.
     pub server_type: Server,
+}
+
+impl From<JavaResponse> for GenericResponse {
+    fn from(r: JavaResponse) -> Self {
+        let clone = r.clone();
+        Self {
+            server_name: None,
+            server_description: Some(r.description),
+            server_game: Some(String::from("Minecraft")),
+            server_game_version: Some(r.version_name),
+            server_map: None,
+            players_maximum: Some(r.players_maximum.into()),
+            players_online: Some(r.players_online.into()),
+            players_bots: None,
+            has_password: None,
+            inner: crate::protocols::SpecificResponse::Minecraft(clone),
+        }
+    }
 }
 
 /// A Bedrock Edition query response.

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -8,9 +8,43 @@
 pub mod gamespy;
 /// Reference: [Server List Ping](https://wiki.vg/Server_List_Ping)
 pub mod minecraft;
+/// Reference: [node-GameDig](https://github.com/gamedig/node-gamedig/blob/master/protocols/quake1.js)
+pub mod quake;
 /// General types that are used by all protocols.
 pub mod types;
 /// Reference: [Server Query](https://developer.valvesoftware.com/wiki/Server_queries)
 pub mod valve;
-/// Reference: [node-GameDig](https://github.com/gamedig/node-gamedig/blob/master/protocols/quake1.js)
-pub mod quake;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum Protocol {
+    Gamespy(gamespy::GameSpyVersion),
+    Minecraft(Option<minecraft::MinecraftVersion>),
+    Quake(quake::QuakeVersion),
+    Valve(valve::SteamApp),
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenericResponse {
+    pub server_name: Option<String>,
+    pub server_description: Option<String>,
+    pub server_game: Option<String>,
+    pub server_game_version: Option<String>,
+    pub server_map: Option<String>,
+    pub players_maximum: Option<u64>,
+    pub players_online: Option<u64>,
+    pub players_bots: Option<u64>,
+    pub has_password: Option<bool>,
+    // TODO: Add players (+rules?)
+    pub inner: SpecificResponse,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpecificResponse {
+    Gamespy(gamespy::ResponseVersion),
+    Minecraft(minecraft::JavaResponse),
+    Quake(quake::Response<()>),
+    Valve(valve::Response),
+}

--- a/src/protocols/quake/mod.rs
+++ b/src/protocols/quake/mod.rs
@@ -1,10 +1,17 @@
-
 pub mod one;
-pub mod two;
 pub mod three;
+pub mod two;
 
 /// All types used by the implementation.
 pub mod types;
 pub use types::*;
 
 mod client;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub enum QuakeVersion {
+    One,
+    Two,
+    Three,
+}

--- a/src/protocols/quake/types.rs
+++ b/src/protocols/quake/types.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::protocols::GenericResponse;
 
 /// General server information's.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -20,4 +22,30 @@ pub struct Response<P> {
     pub version: String,
     /// Other server entries that weren't used.
     pub unused_entries: HashMap<String, String>,
+}
+
+impl<T: Clone> From<Response<T>> for GenericResponse {
+    fn from(r: Response<T>) -> Self {
+        let clone = r.clone();
+        Self {
+            server_name: Some(r.name),
+            server_description: None,
+            server_game: None,
+            server_game_version: Some(r.version),
+            server_map: Some(r.map),
+            players_maximum: Some(r.players_maximum.into()),
+            players_online: Some(r.players_online.into()),
+            players_bots: None,
+            has_password: None,
+            inner: crate::protocols::SpecificResponse::Quake(Response::<()> {
+                players: vec![],
+                name: clone.name,
+                map: clone.map,
+                players_maximum: clone.players_maximum,
+                players_online: clone.players_online,
+                version: clone.version,
+                unused_entries: clone.unused_entries,
+            }),
+        }
+    }
 }

--- a/src/protocols/valve/types.rs
+++ b/src/protocols/valve/types.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use crate::bufferer::Bufferer;
 use crate::GDError::UnknownEnumCast;
 use crate::GDResult;
+use crate::{bufferer::Bufferer, protocols::GenericResponse};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -53,6 +53,24 @@ pub struct Response {
     pub info: ServerInfo,
     pub players: Option<Vec<ServerPlayer>>,
     pub rules: Option<HashMap<String, String>>,
+}
+
+impl From<Response> for GenericResponse {
+    fn from(r: Response) -> Self {
+        let clone = r.clone();
+        GenericResponse {
+            server_name: Some(r.info.name),
+            server_description: None, // TODO: Maybe in extra_data
+            server_game: Some(r.info.game),
+            server_game_version: Some(r.info.version),
+            server_map: Some(r.info.map),
+            players_maximum: Some(r.info.players_maximum.into()),
+            players_online: Some(r.info.players_online.into()),
+            players_bots: Some(r.info.players_bots.into()),
+            has_password: Some(r.info.has_password),
+            inner: crate::protocols::SpecificResponse::Valve(clone),
+        }
+    }
 }
 
 /// General server information's.


### PR DESCRIPTION
This PR adds the ability to store a game as a Game struct which has all the information we need to make a request for that game: default port, protocol (and protocol settings). It also has extra metadata. 

In order to use the game structs with a common function a common return type had to be defined, here I chose to create a struct them implement from on other structs to convert them into the generic type. This has the benefit of not having to pass pointers around like if I had used traits but the downside of cloning the response as I chose to include the original response type within the generic response.

This draft only includes one game for each protocol for testing purposes, if everyone is happy I will go ahead and add the rest.

This would be a replace #42 however we could potentially use a similar build script to generate the game data structures e.g. from node-gamedig/games.txt