### PR TITLE
[PreCommit] Add clippy and rustfmt pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: local
+    hooks:
+      - id: clippy
+        name: Check clippy
+        language: system
+        files: '[.]rs$'
+        pass_filenames: false
+        entry: rustup run --install nightly cargo-clippy -- -- -D warnings
+      - id: format
+        name: Check rustfmt
+        language: system
+        files: '[.]rs$'
+        pass_filenames: false
+        entry: rustup run --install nightly cargo-fmt --check


### PR DESCRIPTION
These hooks can be installed using [pre-commit], with: "pre-commit install". Once installed they will prevent you from committing if the staged code has clippy warnings or hasn't been formatted. You can skip the pre-commit checks by adding the "-n" flag to your git commit command.

The hooks also require rustup as the nightly versions of rustfmt and clippy are used.

[pre-commit]: https://pre-commit.com/