### PR TITLE
Implement generic response as enum

### DIFF
--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -8,8 +8,10 @@ fn generic_query(game_name: &str, addr: &IpAddr, port: Option<u16>) -> GDResult<
     println!("Querying {:#?} with game {:#?}.", addr, game.name);
 
     let response = query(game, addr, port)?;
+    println!("Response: {:#?}", response);
 
-    println!("{:#?}", response);
+    let common = response.as_common();
+    println!("Common response: {:#?}", common);
 
     Ok(response)
 }

--- a/src/games/ffow.rs
+++ b/src/games/ffow.rs
@@ -1,4 +1,4 @@
-use crate::protocols::types::TimeoutSettings;
+use crate::protocols::types::{CommonResponse, TimeoutSettings};
 use crate::protocols::valve::{Engine, Environment, Server, ValveProtocol};
 use crate::protocols::GenericResponse;
 use crate::GDResult;
@@ -46,6 +46,23 @@ pub struct Response {
 
 impl From<Response> for GenericResponse {
     fn from(r: Response) -> Self { GenericResponse::FFOW(r) }
+}
+
+impl From<Response> for CommonResponse {
+    fn from(r: Response) -> Self {
+        CommonResponse {
+            name: Some(r.name),
+            description: Some(r.description),
+            game: Some(r.game_mode),
+            game_version: Some(r.version),
+            map: Some(r.map),
+            players_maximum: r.players_maximum.into(),
+            players_online: r.players_online.into(),
+            players_bots: None,
+            has_password: Some(r.has_password),
+            players: vec![], // TODO: Implement
+        }
+    }
 }
 
 pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {

--- a/src/games/ffow.rs
+++ b/src/games/ffow.rs
@@ -1,4 +1,4 @@
-use crate::protocols::types::{SpecificResponse, TimeoutSettings};
+use crate::protocols::types::TimeoutSettings;
 use crate::protocols::valve::{Engine, Environment, Server, ValveProtocol};
 use crate::protocols::GenericResponse;
 use crate::GDResult;
@@ -44,51 +44,8 @@ pub struct Response {
     pub time_left: u16,
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct ExtraResponse {
-    /// Protocol used by the server.
-    pub protocol: u8,
-    /// Map name.
-    pub active_mod: String,
-    /// Dedicated, NonDedicated or SourceTV
-    pub server_type: Server,
-    /// The Operating System that the server is on.
-    pub environment_type: Environment,
-    /// Indicates whether the server uses VAC.
-    pub vac_secured: bool,
-    /// Current round index.
-    pub round: u8,
-    /// Maximum amount of rounds.
-    pub rounds_maximum: u8,
-    /// Time left for the current round in seconds.
-    pub time_left: u16,
-}
-
 impl From<Response> for GenericResponse {
-    fn from(r: Response) -> Self {
-        Self {
-            name: Some(r.name),
-            description: Some(r.description),
-            game: Some(r.game_mode),
-            game_version: Some(r.version),
-            map: Some(r.map),
-            players_maximum: r.players_maximum.into(),
-            players_online: r.players_online.into(),
-            players_bots: None,
-            has_password: Some(r.has_password),
-            inner: SpecificResponse::FFOW(ExtraResponse {
-                protocol: r.protocol,
-                active_mod: r.active_mod,
-                server_type: r.server_type,
-                environment_type: r.environment_type,
-                vac_secured: r.vac_secured,
-                round: r.round,
-                rounds_maximum: r.rounds_maximum,
-                time_left: r.time_left,
-            }),
-        }
-    }
+    fn from(r: Response) -> Self { GenericResponse::FFOW(r) }
 }
 
 pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -164,9 +164,18 @@ pub fn query(game: &Game, address: &IpAddr, port: Option<u16>) -> GDResult<proto
         }
         Protocol::Quake(version) => {
             match version {
-                QuakeVersion::One => protocols::quake::one::query(&socket_addr, None).map(|r| r.into())?,
-                QuakeVersion::Two => protocols::quake::two::query(&socket_addr, None).map(|r| r.into())?,
-                QuakeVersion::Three => protocols::quake::three::query(&socket_addr, None).map(|r| r.into())?,
+                QuakeVersion::One => {
+                    protocols::quake::one::query(&socket_addr, None)
+                        .map(|r| protocols::quake::VersionedResponse::One(r).into())?
+                }
+                QuakeVersion::Two => {
+                    protocols::quake::two::query(&socket_addr, None)
+                        .map(|r| protocols::quake::VersionedResponse::TwoAndThree(r).into())?
+                }
+                QuakeVersion::Three => {
+                    protocols::quake::three::query(&socket_addr, None)
+                        .map(|r| protocols::quake::VersionedResponse::TwoAndThree(r).into())?
+                }
             }
         }
         Protocol::TheShip => ts::query(address, port).map(|r| r.into())?,

--- a/src/games/ts.rs
+++ b/src/games/ts.rs
@@ -1,6 +1,5 @@
 use crate::{
     protocols::{
-        types::SpecificResponse,
         valve::{self, get_optional_extracted_data, Server, ServerPlayer, SteamApp},
         GenericResponse,
     },
@@ -61,53 +60,8 @@ pub struct Response {
     pub duration: u8,
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-pub struct ExtraResponse {
-    pub protocol: u8,
-    pub player_details: Vec<TheShipPlayer>,
-    pub server_type: Server,
-    pub vac_secured: bool,
-    pub port: Option<u16>,
-    pub steam_id: Option<u64>,
-    pub tv_port: Option<u16>,
-    pub tv_name: Option<String>,
-    pub keywords: Option<String>,
-    pub rules: HashMap<String, String>,
-    pub mode: u8,
-    pub witnesses: u8,
-    pub duration: u8,
-}
-
 impl From<Response> for GenericResponse {
-    fn from(r: Response) -> Self {
-        Self {
-            name: Some(r.name),
-            description: None,
-            game: Some(r.game),
-            game_version: Some(r.version),
-            map: Some(r.map),
-            players_maximum: r.max_players.into(),
-            players_online: r.players.into(),
-            players_bots: Some(r.bots.into()),
-            has_password: Some(r.has_password),
-            inner: SpecificResponse::TheShip(ExtraResponse {
-                protocol: r.protocol,
-                player_details: r.players_details,
-                server_type: r.server_type,
-                vac_secured: r.vac_secured,
-                steam_id: r.steam_id,
-                port: r.port,
-                tv_port: r.tv_port,
-                tv_name: r.tv_name,
-                keywords: r.keywords,
-                rules: r.rules,
-                mode: r.mode,
-                witnesses: r.witnesses,
-                duration: r.duration,
-            }),
-        }
-    }
+    fn from(r: Response) -> Self { GenericResponse::TheShip(r) }
 }
 
 impl Response {

--- a/src/protocols/gamespy/mod.rs
+++ b/src/protocols/gamespy/mod.rs
@@ -16,11 +16,11 @@ pub enum GameSpyVersion {
     Three,
 }
 
-/// Enum of versions and their ExtraResponse data
+/// Versioned response type
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum VersionedExtraResponse {
-    One(one::ExtraResponse),
-    Two(two::ExtraResponse),
-    Three(three::ExtraResponse),
+pub enum VersionedResponse {
+    One(one::Response),
+    Two(two::Response),
+    Three(three::Response),
 }

--- a/src/protocols/gamespy/protocols/one/types.rs
+++ b/src/protocols/gamespy/protocols/one/types.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::gamespy::VersionedResponse;
+use crate::protocols::types::{CommonBorrowedPlayer, CommonBorrowedResponse, CommonPlayer, CommonResponse};
 use crate::protocols::GenericResponse;
 
 /// A player’s details.
@@ -21,6 +22,24 @@ pub struct Player {
     pub deaths: Option<u32>,
     pub health: Option<u32>,
     pub secret: bool,
+}
+
+impl From<Player> for CommonPlayer {
+    fn from(p: Player) -> Self {
+        CommonPlayer {
+            name: p.name,
+            score: p.frags,
+        }
+    }
+}
+
+impl<'a> From<&'a Player> for CommonBorrowedPlayer<'a> {
+    fn from(p: &'a Player) -> Self {
+        CommonBorrowedPlayer {
+            name: &p.name,
+            score: p.frags,
+        }
+    }
 }
 
 /// A query response.
@@ -45,4 +64,40 @@ pub struct Response {
 
 impl From<Response> for GenericResponse {
     fn from(r: Response) -> Self { GenericResponse::GameSpy(VersionedResponse::One(r)) }
+}
+
+impl TryFrom<Response> for CommonResponse {
+    type Error = <u64 as TryFrom<usize>>::Error;
+    fn try_from(r: Response) -> Result<Self, Self::Error> {
+        Ok(CommonResponse {
+            name: Some(r.name),
+            description: None,
+            game: Some(r.game_type),
+            game_version: Some(r.game_version),
+            map: Some(r.map),
+            players_maximum: r.players_maximum.try_into()?,
+            players_online: r.players_online.try_into()?,
+            players_bots: None,
+            has_password: Some(r.has_password),
+            players: r.players.into_iter().map(Player::into).collect(),
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a Response> for CommonBorrowedResponse<'a> {
+    type Error = <u64 as TryFrom<usize>>::Error;
+    fn try_from(r: &'a Response) -> Result<Self, Self::Error> {
+        Ok(CommonBorrowedResponse {
+            name: Some(&r.name),
+            description: None,
+            game: Some(&r.game_type),
+            game_version: Some(&r.game_version),
+            map: Some(&r.map),
+            players_maximum: r.players_maximum.try_into()?,
+            players_online: r.players_online.try_into()?,
+            players_bots: None,
+            has_password: Some(r.has_password),
+            players: r.players.iter().map(|p| p.into()).collect(),
+        })
+    }
 }

--- a/src/protocols/gamespy/protocols/one/types.rs
+++ b/src/protocols/gamespy/protocols/one/types.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::protocols::gamespy::VersionedExtraResponse;
-use crate::protocols::{types::SpecificResponse, GenericResponse};
+use crate::protocols::gamespy::VersionedResponse;
+use crate::protocols::GenericResponse;
 
 /// A player’s details.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -43,40 +43,6 @@ pub struct Response {
     pub unused_entries: HashMap<String, String>,
 }
 
-/// Non-generic query response
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtraResponse {
-    pub map_title: Option<String>,
-    pub admin_contact: Option<String>,
-    pub admin_name: Option<String>,
-    pub players_minimum: Option<u8>,
-    pub tournament: bool,
-    pub unused_entries: HashMap<String, String>,
-    pub players: Vec<Player>,
-}
-
 impl From<Response> for GenericResponse {
-    fn from(r: Response) -> Self {
-        Self {
-            name: Some(r.name),
-            description: None,
-            game: Some(r.game_type),
-            game_version: Some(r.game_version),
-            map: Some(r.map),
-            players_maximum: r.players_maximum.try_into().unwrap(), // FIXME: usize to u64 may fail
-            players_online: r.players_online.try_into().unwrap(),
-            players_bots: None,
-            has_password: Some(r.has_password),
-            inner: SpecificResponse::Gamespy(VersionedExtraResponse::One(ExtraResponse {
-                map_title: r.map_title,
-                admin_contact: r.admin_contact,
-                admin_name: r.admin_name,
-                players_minimum: r.players_minimum,
-                tournament: r.tournament,
-                unused_entries: r.unused_entries,
-                players: r.players,
-            })),
-        }
-    }
+    fn from(r: Response) -> Self { GenericResponse::GameSpy(VersionedResponse::One(r)) }
 }

--- a/src/protocols/gamespy/protocols/three/types.rs
+++ b/src/protocols/gamespy/protocols/three/types.rs
@@ -1,5 +1,6 @@
-use crate::protocols::gamespy::VersionedResponse;
+use crate::protocols::types::{CommonBorrowedPlayer, CommonBorrowedResponse, CommonPlayer};
 use crate::protocols::GenericResponse;
+use crate::protocols::{gamespy::VersionedResponse, types::CommonResponse};
 use std::collections::HashMap;
 
 #[cfg(feature = "serde")]
@@ -15,6 +16,24 @@ pub struct Player {
     pub team: u8,
     pub deaths: u32,
     pub skill: u32,
+}
+
+impl From<Player> for CommonPlayer {
+    fn from(p: Player) -> Self {
+        CommonPlayer {
+            name: p.name,
+            score: p.score.try_into().unwrap(), // FIXME: Should pass error
+        }
+    }
+}
+
+impl<'a> From<&'a Player> for CommonBorrowedPlayer<'a> {
+    fn from(p: &'a Player) -> Self {
+        CommonBorrowedPlayer {
+            name: &p.name,
+            score: p.score.try_into().unwrap(), // FIXME: Should pass error
+        }
+    }
 }
 
 /// A team's details
@@ -45,4 +64,40 @@ pub struct Response {
 
 impl From<Response> for GenericResponse {
     fn from(r: Response) -> Self { GenericResponse::GameSpy(VersionedResponse::Three(r)) }
+}
+
+impl TryFrom<Response> for CommonResponse {
+    type Error = <u64 as TryFrom<usize>>::Error;
+    fn try_from(r: Response) -> Result<Self, Self::Error> {
+        Ok(CommonResponse {
+            name: Some(r.name),
+            description: None,
+            game: Some(r.game_type),
+            game_version: Some(r.game_version),
+            map: Some(r.map),
+            players_maximum: r.players_maximum.try_into()?,
+            players_online: r.players_online.try_into()?,
+            players_bots: None,
+            has_password: Some(r.has_password),
+            players: r.players.into_iter().map(Player::into).collect(),
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a Response> for CommonBorrowedResponse<'a> {
+    type Error = <u64 as TryFrom<usize>>::Error;
+    fn try_from(r: &'a Response) -> Result<Self, Self::Error> {
+        Ok(CommonBorrowedResponse {
+            name: Some(&r.name),
+            description: None,
+            game: Some(&r.game_type),
+            game_version: Some(&r.game_version),
+            map: Some(&r.map),
+            players_maximum: r.players_maximum.try_into()?,
+            players_online: r.players_online.try_into()?,
+            players_bots: None,
+            has_password: Some(r.has_password),
+            players: r.players.iter().map(|p| p.into()).collect(),
+        })
+    }
 }

--- a/src/protocols/gamespy/protocols/three/types.rs
+++ b/src/protocols/gamespy/protocols/three/types.rs
@@ -1,5 +1,5 @@
-use crate::protocols::gamespy::VersionedExtraResponse;
-use crate::protocols::{types::SpecificResponse, GenericResponse};
+use crate::protocols::gamespy::VersionedResponse;
+use crate::protocols::GenericResponse;
 use std::collections::HashMap;
 
 #[cfg(feature = "serde")]
@@ -43,36 +43,6 @@ pub struct Response {
     pub unused_entries: HashMap<String, String>,
 }
 
-/// Non-generic query response
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtraResponse {
-    pub players_minimum: Option<u8>,
-    pub teams: Vec<Team>,
-    pub tournament: bool,
-    pub unused_entries: HashMap<String, String>,
-    pub players: Vec<Player>,
-}
-
 impl From<Response> for GenericResponse {
-    fn from(r: Response) -> Self {
-        Self {
-            name: Some(r.name),
-            description: None,
-            game: Some(r.game_type),
-            game_version: Some(r.game_version),
-            map: Some(r.map),
-            players_maximum: r.players_maximum.try_into().unwrap(), // FIXME: usize to u64 may fail
-            players_online: r.players_online.try_into().unwrap(),
-            players_bots: None,
-            has_password: Some(r.has_password),
-            inner: SpecificResponse::Gamespy(VersionedExtraResponse::Three(ExtraResponse {
-                players_minimum: r.players_minimum,
-                teams: r.teams,
-                tournament: r.tournament,
-                unused_entries: r.unused_entries,
-                players: r.players,
-            })),
-        }
-    }
+    fn from(r: Response) -> Self { GenericResponse::GameSpy(VersionedResponse::Three(r)) }
 }

--- a/src/protocols/gamespy/protocols/two/types.rs
+++ b/src/protocols/gamespy/protocols/two/types.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use crate::protocols::gamespy::VersionedExtraResponse;
-use crate::protocols::types::SpecificResponse;
+use crate::protocols::gamespy::VersionedResponse;
 use crate::protocols::GenericResponse;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -36,34 +35,6 @@ pub struct Response {
     pub unused_entries: HashMap<String, String>,
 }
 
-/// Non-generic query response
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtraResponse {
-    pub teams: Vec<Team>,
-    pub players_minimum: Option<u8>,
-    pub unused_entries: HashMap<String, String>,
-    pub players: Vec<Player>,
-}
-
 impl From<Response> for GenericResponse {
-    fn from(r: Response) -> Self {
-        Self {
-            name: Some(r.name),
-            description: None,
-            game: None,
-            game_version: None,
-            map: Some(r.map),
-            players_maximum: r.players_maximum.try_into().unwrap(), // FIXME: usize to u64 may fail
-            players_online: r.players_online.try_into().unwrap(),
-            players_bots: None,
-            has_password: Some(r.has_password),
-            inner: SpecificResponse::Gamespy(VersionedExtraResponse::Two(ExtraResponse {
-                teams: r.teams,
-                players_minimum: r.players_minimum,
-                unused_entries: r.unused_entries,
-                players: r.players,
-            })),
-        }
-    }
+    fn from(r: Response) -> Self { GenericResponse::GameSpy(VersionedResponse::Two(r)) }
 }

--- a/src/protocols/gamespy/protocols/two/types.rs
+++ b/src/protocols/gamespy/protocols/two/types.rs
@@ -58,36 +58,38 @@ impl From<Response> for GenericResponse {
     fn from(r: Response) -> Self { GenericResponse::GameSpy(VersionedResponse::Two(r)) }
 }
 
-impl From<Response> for CommonResponse {
-    fn from(r: Response) -> Self {
-        CommonResponse {
+impl TryFrom<Response> for CommonResponse {
+    type Error = <u64 as TryFrom<usize>>::Error;
+    fn try_from(r: Response) -> Result<Self, Self::Error> {
+        Ok(CommonResponse {
             name: Some(r.name),
             description: None,
             game: None,
             game_version: None,
             map: Some(r.map),
-            players_maximum: r.players_maximum.try_into().unwrap(),
-            players_online: r.players_online.try_into().unwrap(),
+            players_maximum: r.players_maximum.try_into()?,
+            players_online: r.players_online.try_into()?,
             players_bots: None,
             has_password: None,
             players: r.players.into_iter().map(Player::into).collect(),
-        }
+        })
     }
 }
 
-impl<'a> From<&'a Response> for CommonBorrowedResponse<'a> {
-    fn from(r: &'a Response) -> Self {
-        CommonBorrowedResponse {
+impl<'a> TryFrom<&'a Response> for CommonBorrowedResponse<'a> {
+    type Error = <u64 as TryFrom<usize>>::Error;
+    fn try_from(r: &'a Response) -> Result<Self, Self::Error> {
+        Ok(CommonBorrowedResponse {
             name: Some(&r.name),
             description: None,
             game: None,
             game_version: None,
             map: Some(&r.map),
-            players_maximum: r.players_maximum.try_into().unwrap(),
-            players_online: r.players_online.try_into().unwrap(),
+            players_maximum: r.players_maximum.try_into()?,
+            players_online: r.players_online.try_into()?,
             players_bots: None,
             has_password: None,
             players: r.players.iter().map(|p| p.into()).collect(),
-        }
+        })
     }
 }

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     bufferer::Bufferer,
-    protocols::{types::SpecificResponse, GenericResponse},
+    protocols::GenericResponse,
     GDError::{PacketBad, UnknownEnumCast},
     GDResult,
 };
@@ -44,11 +44,12 @@ pub struct Player {
     pub id: String,
 }
 
+/// Versioned response type
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum VersionedExtraResponse {
-    Bedrock(BedrockExtraResponse),
-    Java(JavaExtraResponse),
+#[derive(Debug, Clone, PartialEq)]
+pub enum VersionedResponse {
+    Bedrock(BedrockResponse),
+    Java(JavaResponse),
 }
 
 /// A Java query response.
@@ -78,47 +79,8 @@ pub struct JavaResponse {
     pub server_type: Server,
 }
 
-/// Non-generic java response
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct JavaExtraResponse {
-    /// Version protocol, example: 760 (for 1.19.2). Note that for versions
-    /// below 1.6 this field is always -1.
-    pub version_protocol: i32,
-    /// Some online players (can be missing).
-    pub players_sample: Option<Vec<Player>>,
-    /// The favicon (can be missing).
-    pub favicon: Option<String>,
-    /// Tells if the chat preview is enabled (can be missing).
-    pub previews_chat: Option<bool>,
-    /// Tells if secure chat is enforced (can be missing).
-    pub enforces_secure_chat: Option<bool>,
-    /// Tell's the server type.
-    pub server_type: Server,
-}
-
 impl From<JavaResponse> for GenericResponse {
-    fn from(r: JavaResponse) -> Self {
-        Self {
-            name: None,
-            description: Some(r.description),
-            game: Some(String::from("Minecraft")),
-            game_version: Some(r.version_name),
-            map: None,
-            players_maximum: r.players_maximum.into(),
-            players_online: r.players_online.into(),
-            players_bots: None,
-            has_password: None,
-            inner: SpecificResponse::Minecraft(VersionedExtraResponse::Java(JavaExtraResponse {
-                version_protocol: r.version_protocol,
-                players_sample: r.players_sample,
-                favicon: r.favicon,
-                previews_chat: r.previews_chat,
-                enforces_secure_chat: r.enforces_secure_chat,
-                server_type: r.server_type,
-            })),
-        }
-    }
+    fn from(r: JavaResponse) -> Self { GenericResponse::Minecraft(VersionedResponse::Java(r)) }
 }
 
 /// A Bedrock Edition query response.
@@ -147,43 +109,8 @@ pub struct BedrockResponse {
     pub server_type: Server,
 }
 
-/// Non-generic bedrock response
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct BedrockExtraResponse {
-    /// Server's edition.
-    pub edition: String,
-    /// Version protocol, example: 760 (for 1.19.2).
-    pub version_protocol: String,
-    /// Server id.
-    pub id: Option<String>,
-    /// Current game mode.
-    pub game_mode: Option<GameMode>,
-    /// Tells the server type.
-    pub server_type: Server,
-}
-
 impl From<BedrockResponse> for GenericResponse {
-    fn from(r: BedrockResponse) -> Self {
-        Self {
-            name: Some(r.name),
-            description: None,
-            game: None,
-            game_version: Some(r.version_name),
-            map: r.map,
-            players_maximum: r.players_maximum.into(),
-            players_online: r.players_online.into(),
-            players_bots: None,
-            has_password: None,
-            inner: SpecificResponse::Minecraft(VersionedExtraResponse::Bedrock(BedrockExtraResponse {
-                edition: r.edition,
-                version_protocol: r.version_protocol,
-                id: r.id,
-                game_mode: r.game_mode,
-                server_type: r.server_type,
-            })),
-        }
-    }
+    fn from(r: BedrockResponse) -> Self { GenericResponse::Minecraft(VersionedResponse::Bedrock(r)) }
 }
 
 impl JavaResponse {

--- a/src/protocols/quake/types.rs
+++ b/src/protocols/quake/types.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::protocols::{types::SpecificResponse, GenericResponse};
+use crate::protocols::GenericResponse;
 
 /// General server information's.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -24,30 +24,14 @@ pub struct Response<P> {
     pub unused_entries: HashMap<String, String>,
 }
 
-/// Non-generic quake response
+/// Versioned response type
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ExtraResponse {
-    /// Other server entries that weren't used.
-    pub unused_entries: HashMap<String, String>,
+pub enum VersionedResponse {
+    One(Response<crate::protocols::quake::one::Player>),
+    TwoAndThree(Response<crate::protocols::quake::two::Player>),
 }
 
-impl<T> From<Response<T>> for GenericResponse {
-    fn from(r: Response<T>) -> Self {
-        Self {
-            name: Some(r.name),
-            description: None,
-            game: None,
-            game_version: Some(r.version),
-            map: Some(r.map),
-            players_maximum: r.players_maximum.into(),
-            players_online: r.players_online.into(),
-            players_bots: None,
-            has_password: None,
-            inner: SpecificResponse::Quake(ExtraResponse {
-                // TODO: Players
-                unused_entries: r.unused_entries,
-            }),
-        }
-    }
+impl From<VersionedResponse> for GenericResponse {
+    fn from(r: VersionedResponse) -> Self { GenericResponse::Quake(r) }
 }

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -63,17 +63,17 @@ pub enum GenericResponse {
 /// Common response fields
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct CommonResponse {
+pub struct CommonResponseImpl<StringType> {
     /// The name of the server
-    pub name: Option<String>,
+    pub name: Option<StringType>,
     /// Description of the server
-    pub description: Option<String>,
+    pub description: Option<StringType>,
     /// Name of the current game or game mode
-    pub game: Option<String>,
+    pub game: Option<StringType>,
     /// Version of the game being run on the server
-    pub game_version: Option<String>,
+    pub game_version: Option<StringType>,
     /// The current map name
-    pub map: Option<String>,
+    pub map: Option<StringType>,
     /// Maximum number of players allowed to connect
     pub players_maximum: u64,
     /// Number of players currently connected
@@ -83,54 +83,24 @@ pub struct CommonResponse {
     /// Whether the server requires a password to join
     pub has_password: Option<bool>,
     /// Currently connected players
-    pub players: Vec<CommonPlayer>,
+    pub players: Vec<CommonPlayerImpl<StringType>>,
 }
 
-/// Common response fields (not owned)
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-pub struct CommonBorrowedResponse<'a> {
-    /// The name of the server
-    pub name: Option<&'a String>,
-    /// Description of the server
-    pub description: Option<&'a String>,
-    /// Name of the current game or game mode
-    pub game: Option<&'a String>,
-    /// Version of the game being run on the server
-    pub game_version: Option<&'a String>,
-    /// The current map name
-    pub map: Option<&'a String>,
-    /// Maximum number of players allowed to connect
-    pub players_maximum: u64,
-    /// Number of players currently connected
-    pub players_online: u64,
-    /// Number of bots currently connected
-    pub players_bots: Option<u64>,
-    /// Whether the server requires a password to join
-    pub has_password: Option<bool>,
-    /// Currently connected players
-    pub players: Vec<CommonBorrowedPlayer<'a>>,
-}
+pub type CommonResponse = CommonResponseImpl<String>;
+pub type CommonBorrowedResponse<'a> = CommonResponseImpl<&'a String>;
 
 /// Common player fields
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct CommonPlayer {
+pub struct CommonPlayerImpl<StringType> {
     /// Player's name.
-    pub name: String,
+    pub name: StringType,
     /// General score.
     pub score: u32,
 }
 
-/// Common player fields
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-pub struct CommonBorrowedPlayer<'a> {
-    /// Player's name.
-    pub name: &'a String,
-    /// General score.
-    pub score: u32,
-}
+pub type CommonPlayer = CommonPlayerImpl<String>;
+pub type CommonBorrowedPlayer<'a> = CommonPlayerImpl<&'a String>;
 
 impl GenericResponse {
     pub fn into_common(self) -> CommonResponse {

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -102,22 +102,25 @@ pub struct CommonPlayerImpl<StringType> {
 pub type CommonPlayer = CommonPlayerImpl<String>;
 pub type CommonBorrowedPlayer<'a> = CommonPlayerImpl<&'a String>;
 
-impl GenericResponse {
-    pub fn into_common(self) -> CommonResponse {
-        match self {
-            GenericResponse::FFOW(r) => r.into(),
+macro_rules! common_conversion {
+    ($self:ident) => {
+        match $self {
             GenericResponse::Valve(r) => r.into(),
+            GenericResponse::GameSpy(v) => {
+                match v {
+                    gamespy::VersionedResponse::One(r) => r.try_into().unwrap(),
+                    gamespy::VersionedResponse::Two(r) => r.try_into().unwrap(),
+                    gamespy::VersionedResponse::Three(r) => r.try_into().unwrap(),
+                }
+            }
             _ => todo!(),
         }
-    }
+    };
+}
 
-    pub fn as_common(&self) -> CommonBorrowedResponse {
-        match self {
-            GenericResponse::Valve(r) => r.into(),
-            GenericResponse::GameSpy(gamespy::VersionedResponse::Two(r)) => r.into(),
-            _ => todo!(),
-        }
-    }
+impl GenericResponse {
+    pub fn into_common(self) -> CommonResponse { common_conversion!(self) }
+    pub fn as_common(&self) -> CommonBorrowedResponse { common_conversion!(self) }
 }
 
 /// Timeout settings for socket operations

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -60,63 +60,93 @@ pub enum GenericResponse {
     FFOW(crate::games::ffow::Response),
 }
 
-impl GenericResponse {
+/// Common response fields
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommonResponse {
     /// The name of the server
-    pub fn name(&self) -> Option<&String> {
-        todo!();
-    }
+    pub name: Option<String>,
     /// Description of the server
-    pub fn description(&self) -> Option<&String> {
-        match self {
-            GenericResponse::Minecraft(minecraft::VersionedResponse::Java(r)) => Some(&r.description),
-            GenericResponse::FFOW(r) => Some(&r.description),
-            _ => None,
-        }
-    }
+    pub description: Option<String>,
     /// Name of the current game or game mode
-    pub fn game(&self) -> Option<String> {
-        todo!();
-    }
+    pub game: Option<String>,
     /// Version of the game being run on the server
-    pub fn game_version(&self) -> Option<String> {
-        todo!();
-    }
+    pub game_version: Option<String>,
     /// The current map name
-    pub fn map(&self) -> Option<String> {
-        todo!();
-    }
+    pub map: Option<String>,
     /// Maximum number of players allowed to connect
-    pub fn players_maximum(&self) -> u64 {
+    pub players_maximum: u64,
+    /// Number of players currently connected
+    pub players_online: u64,
+    /// Number of bots currently connected
+    pub players_bots: Option<u64>,
+    /// Whether the server requires a password to join
+    pub has_password: Option<bool>,
+    /// Currently connected players
+    pub players: Vec<CommonPlayer>,
+}
+
+/// Common response fields (not owned)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommonBorrowedResponse<'a> {
+    /// The name of the server
+    pub name: Option<&'a String>,
+    /// Description of the server
+    pub description: Option<&'a String>,
+    /// Name of the current game or game mode
+    pub game: Option<&'a String>,
+    /// Version of the game being run on the server
+    pub game_version: Option<&'a String>,
+    /// The current map name
+    pub map: Option<&'a String>,
+    /// Maximum number of players allowed to connect
+    pub players_maximum: u64,
+    /// Number of players currently connected
+    pub players_online: u64,
+    /// Number of bots currently connected
+    pub players_bots: Option<u64>,
+    /// Whether the server requires a password to join
+    pub has_password: Option<bool>,
+    /// Currently connected players
+    pub players: Vec<CommonBorrowedPlayer<'a>>,
+}
+
+/// Common player fields
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommonPlayer {
+    /// Player's name.
+    pub name: String,
+    /// General score.
+    pub score: u32,
+}
+
+/// Common player fields
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommonBorrowedPlayer<'a> {
+    /// Player's name.
+    pub name: &'a String,
+    /// General score.
+    pub score: u32,
+}
+
+impl GenericResponse {
+    pub fn into_common(self) -> CommonResponse {
         match self {
-            GenericResponse::FFOW(r) => r.players_maximum.into(),
-            GenericResponse::Quake(r) => match r {
-                quake::VersionedResponse::One(r) => r.players_maximum.into(),
-                quake::VersionedResponse::TwoAndThree(r) => r.players_maximum.into(),
-            },
-            GenericResponse::GameSpy(r) => match r {
-                gamespy::VersionedResponse::One(r) => r.players_maximum.try_into().unwrap(),
-                gamespy::VersionedResponse::Two(r) => r.players_maximum.try_into().unwrap(),
-                gamespy::VersionedResponse::Three(r) => r.players_maximum.try_into().unwrap(),
-            },
-            GenericResponse::TheShip(r) => r.max_players.into(),
-            GenericResponse::Minecraft(r) => match r {
-                minecraft::VersionedResponse::Java(r) => r.players_maximum.into(),
-                minecraft::VersionedResponse::Bedrock(r) => r.players_maximum.into(),
-            },
-            GenericResponse::Valve(r) => r.info.players_maximum.into(),
+            GenericResponse::FFOW(r) => r.into(),
+            GenericResponse::Valve(r) => r.into(),
+            _ => todo!(),
         }
     }
-    /// Number of players currently connected
-    pub fn players_online(&self) -> u64 {
-        todo!();
-    }
-    /// Number of bots currently connected
-    pub fn players_bots(&self) -> Option<u64> {
-        todo!();
-    }
-    /// Whether the server requires a password to join
-    pub fn has_password(&self) -> Option<bool> {
-        todo!();
+
+    pub fn as_common(&self) -> CommonBorrowedResponse {
+        match self {
+            GenericResponse::Valve(r) => r.into(),
+            GenericResponse::GameSpy(gamespy::VersionedResponse::Two(r)) => r.into(),
+            _ => todo!(),
+        }
     }
 }
 

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -19,7 +19,6 @@ use crate::{
             SteamApp,
         },
     },
-
     socket::{Socket, UdpSocket},
     utils::u8_lower_upper,
     GDError::{BadGame, Decompress, UnknownEnumCast},

--- a/src/protocols/valve/types.rs
+++ b/src/protocols/valve/types.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 
 use crate::GDError::UnknownEnumCast;
 use crate::GDResult;
-use crate::{
-    bufferer::Bufferer,
-    protocols::{types::SpecificResponse, GenericResponse},
-};
+use crate::{bufferer::Bufferer, protocols::GenericResponse};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -58,62 +55,8 @@ pub struct Response {
     pub rules: Option<HashMap<String, String>>,
 }
 
-/// Non-generic valve response
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-pub struct ExtraResponse {
-    pub players: Option<Vec<ServerPlayer>>,
-    pub rules: Option<HashMap<String, String>>,
-    /// Protocol used by the server.
-    pub protocol: u8,
-    /// Name of the folder containing the game files.
-    pub folder: String,
-    /// [Steam Application ID](https://developer.valvesoftware.com/wiki/Steam_Application_ID) of game.
-    pub appid: u32,
-    /// Dedicated, NonDedicated or SourceTV
-    pub server_type: Server,
-    /// The Operating System that the server is on.
-    pub environment_type: Environment,
-    /// Indicates whether the server uses VAC.
-    pub vac_secured: bool,
-    /// [The ship](https://developer.valvesoftware.com/wiki/The_Ship) extra data
-    pub the_ship: Option<TheShip>,
-    /// Some extra data that the server might provide or not.
-    pub extra_data: Option<ExtraData>,
-    /// GoldSrc only: Indicates whether the hosted game is a mod.
-    pub is_mod: bool,
-    /// GoldSrc only: If the game is a mod, provide additional data.
-    pub mod_data: Option<ModData>,
-}
-
 impl From<Response> for GenericResponse {
-    fn from(r: Response) -> Self {
-        GenericResponse {
-            name: Some(r.info.name),
-            description: None,
-            game: Some(r.info.game),
-            game_version: Some(r.info.version),
-            map: Some(r.info.map),
-            players_maximum: r.info.players_maximum.into(),
-            players_online: r.info.players_online.into(),
-            players_bots: Some(r.info.players_bots.into()),
-            has_password: Some(r.info.has_password),
-            inner: SpecificResponse::Valve(ExtraResponse {
-                players: r.players,
-                rules: r.rules,
-                protocol: r.info.protocol,
-                folder: r.info.folder,
-                appid: r.info.appid,
-                server_type: r.info.server_type,
-                environment_type: r.info.environment_type,
-                vac_secured: r.info.vac_secured,
-                the_ship: r.info.the_ship,
-                extra_data: r.info.extra_data,
-                is_mod: r.info.is_mod,
-                mod_data: r.info.mod_data,
-            }),
-        }
-    }
+    fn from(r: Response) -> Self { GenericResponse::Valve(r) }
 }
 
 /// General server information's.


### PR DESCRIPTION
An implementation of generic response types using a raw response enum as discussed in #48 .

In principle it seems simpler and more elegant but I would like feedback as spaghetti was beginning to form:

https://github.com/Douile/rust-gamedig/blob/7dcecde1aa13c02a0d40d2eb7bbafc91a9365a9b/src/protocols/types.rs#L89-L108