### PR TITLE
[CI] Pin specific rustfmt version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Formatting nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-03-01
+          toolchain: nightly-2023-03-01-x86_64-unknown-linux-gnu
           components: rustfmt
       - name: Run Formatting check
         run: cargo +nightly fmt --check --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Install Formatting nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-03-01-x86_64-unknown-linux-gnu
+          toolchain: nightly-2023-03-01
           components: rustfmt
       - name: Run Formatting check
-        run: cargo +nightly fmt --check --verbose
+        run: cargo +nightly-2023-03-01 fmt --check --verbose
       - name: Install MSRV
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Run Build
-      run: cargo build --verbose
-    - name: Run Clippy
-      run: cargo clippy --verbose
-    - name: Run Tests
-      run: cargo test --verbose
-    - name: Install Formatting nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        components: rustfmt
-    - name: Run Formatting check
-      run: cargo +nightly fmt --check --verbose
-    - name: Install Audit
-      run: cargo install cargo-audit
-    - name: Run Audit
-      run: cargo audit --deny warnings
-    - name: Install MSRV
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.60.0
-        override: true
-    - name: Run MSRV
-      run: cargo build
+      - uses: actions/checkout@v3
+      - name: Run Build
+        run: cargo build --verbose
+      - name: Run Clippy
+        run: cargo clippy --verbose
+      - name: Run Tests
+        run: cargo test --verbose
+      - name: Install Audit
+        run: cargo install cargo-audit
+      - name: Run Audit
+        run: cargo audit --deny warnings
+      - name: Install Formatting nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2023-03-01
+          components: rustfmt
+      - name: Run Formatting check
+        run: cargo +nightly fmt --check --verbose
+      - name: Install MSRV
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.60.0
+          override: true
+      - name: Run MSRV
+        run: cargo build


### PR DESCRIPTION
Pins a specific nightly version to fix errors in CI regarding version mismatch.
Also reorders the check flow to move formatting to the 2nd last place.