### PR TITLE
Add rich error type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install MSRV
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.65.0
           override: true
       - name: Run MSRV
         run: cargo build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         language: system
         files: '[.]rs$'
         pass_filenames: false
-        entry: rustup run --install 1.60 cargo build
+        entry: rustup run --install 1.65 cargo build
       - id: docs
         name: Check rustdoc compiles
         language: system

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/gamedig/latest/gamedig/"
 repository = "https://github.com/gamedig/rust-gamedig"
 readme = "README.md"
 keywords = ["server", "query", "game", "check", "status"]
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 
 [features]
 default = ["games", "services", "game_defs"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ within the library or want to request a feature, it's better to do so here rathe
 on Discord.
 
 ## Usage
-Minimum Supported Rust Version is `1.60.0` and the code is cross-platform.
+Minimum Supported Rust Version is `1.65.0` and the code is cross-platform.
 
 Pick a game/service/protocol (check the [GAMES](GAMES.md), [SERVICES](SERVICES.md) and [PROTOCOLS](PROTOCOLS.md) files to see the currently supported ones), provide the ip and the port (be aware that some game servers use a separate port for the info queries, the port can also be optional if the server is running the default ports) then query on it.  
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,11 +1,12 @@
 # MSRV (Minimum Supported Rust Version)
 
-Current: `1.60.0`
+Current: `1.65.0`
 
 Places to update:
 - `Cargo.toml`
 - `README.md`
 - `.github/workflows/ci.yml`
+- `.pre-commit-config.yaml`
 
 # rustfmt version
 
@@ -22,5 +23,5 @@ The toolchain version used to run rustfmt in CI
 Current: `nightly-2023-07-09`
 
 Places to update:
-- `./.github/workflows/ci.yml`
-- `./.pre-commit-config.yaml`
+- `.github/workflows/ci.yml`
+- `.pre-commit-config.yaml`

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,5 @@
-use crate::GDError::PacketBad;
-use crate::GDError::PacketUnderflow;
+use crate::GDErrorKind::PacketBad;
+use crate::GDErrorKind::PacketUnderflow;
 use crate::GDResult;
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use std::{convert::TryInto, marker::PhantomData};
@@ -547,6 +547,9 @@ mod tests {
         let mut buffer = Buffer::<LittleEndian>::new(data);
 
         let result: Result<u32, _> = buffer.read();
-        assert_eq!(result.unwrap_err(), crate::GDError::PacketUnderflow.into());
+        assert_eq!(
+            result.unwrap_err(),
+            crate::GDErrorKind::PacketUnderflow.into()
+        );
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -108,7 +108,7 @@ impl<'a, B: ByteOrder> Buffer<'a, B> {
         // If the size of `T` is larger than the remaining length, return an error
         // because we don't have enough data left to read.
         if size > remaining {
-            return Err(PacketUnderflow.rich(format!(
+            return Err(PacketUnderflow.context(format!(
                 "Size requested {} was larger than remaining bytes {}",
                 size, remaining
             )));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,6 @@
 use crate::GDError::PacketBad;
-use crate::{GDResult, GDRichError};
+use crate::GDError::PacketUnderflow;
+use crate::GDResult;
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use std::{convert::TryInto, marker::PhantomData};
 
@@ -107,7 +108,7 @@ impl<'a, B: ByteOrder> Buffer<'a, B> {
         // If the size of `T` is larger than the remaining length, return an error
         // because we don't have enough data left to read.
         if size > remaining {
-            return Err(GDRichError::packet_underflow_from_into(format!(
+            return Err(PacketUnderflow.rich(format!(
                 "Size requested {} was larger than remaining bytes {}",
                 size, remaining
             )));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -268,10 +268,10 @@ macro_rules! impl_buffer_read {
         impl<B: ByteOrder> BufferRead<B> for $type {
             fn read_from_buffer(data: &[u8]) -> GDResult<Self> {
                 // Convert the byte slice into an array of the appropriate type.
-                let array = data.try_into().map_err(|_| {
+                let array = data.try_into().map_err(|e| {
                     // If conversion fails, return an error indicating the required and provided
                     // lengths.
-                    PacketBad
+                    PacketBad.context(e)
                 })?;
 
                 // Use the provided function to read the data from the array into the given
@@ -349,7 +349,7 @@ impl StringDecoder for Utf8Decoder {
             &data[.. position]
         )
         // If the data cannot be converted into a UTF-8 string, return an error
-            .map_err(|_| PacketBad)?
+            .map_err(|e| PacketBad.context(e))?
             // Convert the resulting &str into a String
             .to_owned();
 
@@ -397,7 +397,7 @@ impl<B: ByteOrder> StringDecoder for Utf16Decoder<B> {
         B::read_u16_into(&data[.. position], &mut paired_buf);
 
         // Convert the buffer of u16 values into a String
-        let result = String::from_utf16(&paired_buf).map_err(|_| PacketBad)?;
+        let result = String::from_utf16(&paired_buf).map_err(|e| PacketBad.context(e))?;
 
         // Update the cursor position
         // The +2 accounts for the delimiter

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,7 +50,9 @@ impl Error for GDError {}
 
 impl GDError {
     /// Convert error kind into a rich error with a source (and implicit
-    /// backtrace) ```
+    /// backtrace)
+    ///
+    /// ```
     /// thing.parse().map_err(|e| GDError::TypeParse.rich(e))
     /// ```
     pub fn rich<E: Into<Box<dyn std::error::Error + 'static>>>(self, source: E) -> GDRichError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,6 +48,16 @@ impl fmt::Display for GDError {
 
 impl Error for GDError {}
 
+impl GDError {
+    /// Convert error kind into a rich error with a source (and implicit
+    /// backtrace) ```
+    /// thing.parse().map_err(|e| GDError::TypeParse.rich(e))
+    /// ```
+    pub fn rich<E: Into<Box<dyn std::error::Error + 'static>>>(self, source: E) -> GDRichError {
+        GDRichError::from_error(self, source)
+    }
+}
+
 type ErrorSource = Box<dyn std::error::Error + 'static>;
 
 /// Rich gamedig error with backtrace and source
@@ -106,37 +116,10 @@ impl GDRichError {
             backtrace,
         }
     }
-    // Helpers for creating specific kinds of Rich Errors
-    pub fn packet_underflow(source: Option<ErrorSource>) -> Self { Self::new(GDError::PacketUnderflow, source) }
-    pub fn packet_bad(source: Option<ErrorSource>) -> Self { Self::new(GDError::PacketBad, source) }
-    pub fn protocol_format(source: Option<ErrorSource>) -> Self { Self::new(GDError::ProtocolFormat, source) }
-    pub fn unknown_enum_cast(source: Option<ErrorSource>) -> Self { Self::new(GDError::UnknownEnumCast, source) }
-    pub fn invalid_input(source: Option<ErrorSource>) -> Self { Self::new(GDError::InvalidInput, source) }
-    pub fn decompress(source: Option<ErrorSource>) -> Self { Self::new(GDError::Decompress, source) }
-    pub fn type_parse(source: Option<ErrorSource>) -> Self { Self::new(GDError::TypeParse, source) }
 
-    // Helpers for converting source types, these were added as needed feel free to
-    // add your own
-    pub fn packet_underflow_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::packet_underflow(Some(source.into()))
-    }
-    pub fn packet_bad_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::packet_bad(Some(source.into()))
-    }
-    pub fn protocol_format_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::protocol_format(Some(source.into()))
-    }
-    pub fn unknown_enum_cast_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::unknown_enum_cast(Some(source.into()))
-    }
-    pub fn invalid_input_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::invalid_input(Some(source.into()))
-    }
-    pub fn decompress_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::decompress(Some(source.into()))
-    }
-    pub fn type_parse_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
-        Self::type_parse(Some(source.into()))
+    /// Create a new rich error using any type that can be converted to an error
+    pub fn from_error<E: Into<Box<dyn std::error::Error + 'static>>>(kind: GDError, source: E) -> Self {
+        Self::new(kind, Some(source.into()))
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,12 +42,6 @@ pub enum GDErrorKind {
     TypeParse,
 }
 
-impl fmt::Display for GDErrorKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { write!(f, "{:?}", self) }
-}
-
-impl Error for GDErrorKind {}
-
 impl GDErrorKind {
     /// Convert error kind into a full error with a source (and implicit
     /// backtrace)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -170,6 +170,59 @@ mod tests {
         assert_eq!(error, cloned_error);
     }
 
-    // TODO: test display GDError
-    // TODO: test error trait GDError
+    // test display GDError
+    #[test]
+    fn test_display() {
+        let err = GDErrorKind::BadGame.context("Rust is not a game");
+        let s = format!("{}", err);
+        println!("{}", s);
+        assert_eq!(
+            s,
+            "GDError{ kind=BadGame\n  source=\"Rust is not a game\"\n  backtrace=<disabled>\n}\n"
+        );
+    }
+
+    // test error trait GDError
+    #[test]
+    fn test_error_trait() {
+        let source: Result<u32, _> = "nan".parse();
+        let source_err = source.unwrap_err();
+
+        let error_with_context = GDErrorKind::TypeParse.context(source_err.clone());
+        assert!(error_with_context.source().is_some());
+        assert_eq!(
+            format!("{}", error_with_context.source().unwrap()),
+            format!("{}", source_err)
+        );
+
+        let error_without_context: GDError = GDErrorKind::TypeParse.into();
+        assert!(error_without_context.source().is_none());
+    }
+
+    // Test creating GDError with GDError::new
+    #[test]
+    fn test_create_new() {
+        let error_from_new = GDError::new(GDErrorKind::InvalidInput, None);
+        assert!(error_from_new.backtrace.is_some());
+        assert_eq!(error_from_new.kind, GDErrorKind::InvalidInput);
+        assert!(error_from_new.source.is_none());
+    }
+
+    // Test creating GDError with GDErrorKind::context
+    #[test]
+    fn test_create_context() {
+        let error_from_context = GDErrorKind::InvalidInput.context("test");
+        assert!(error_from_context.backtrace.is_some());
+        assert_eq!(error_from_context.kind, GDErrorKind::InvalidInput);
+        assert!(error_from_context.source.is_some());
+    }
+
+    // Test creating GDError with From<GDErrorKind> for GDError
+    #[test]
+    fn test_create_into() {
+        let error_from_into: GDError = GDErrorKind::InvalidInput.into();
+        assert!(error_from_into.backtrace.is_some());
+        assert_eq!(error_from_into.kind, GDErrorKind::InvalidInput);
+        assert!(error_from_into.source.is_none());
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,7 +29,7 @@ pub enum GDError {
     /// Invalid input.
     InvalidInput,
     /// The server queried is not the queried game server.
-    BadGame(String),
+    BadGame,
     /// Couldn't automatically query.
     AutoQuery,
     /// A protocol-defined expected format was not met.
@@ -160,7 +160,7 @@ mod tests {
     // Testing cloning the GDError type
     #[test]
     fn test_cloning() {
-        let error = GDError::BadGame(String::from("MyGame"));
+        let error = GDError::BadGame;
         let cloned_error = error.clone();
         assert_eq!(error, cloned_error);
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,11 @@
 use std::{
+    backtrace,
     error::Error,
     fmt::{self, Formatter},
 };
 
 /// Result of Type and GDError.
-pub type GDResult<T> = Result<T, GDError>;
+pub type GDResult<T> = Result<T, GDRichError>;
 
 /// GameDig Error.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,10 +42,102 @@ pub enum GDError {
     TypeParse,
 }
 
-impl Error for GDError {}
-
 impl fmt::Display for GDError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { write!(f, "{:?}", self) }
+}
+
+impl Error for GDError {}
+
+type ErrorSource = Box<dyn std::error::Error + 'static>;
+
+/// Rich gamedig error with backtrace and source
+/// ```
+/// GDRichError::packet_bad_from_into("Reason packet was bad")
+/// ```
+pub struct GDRichError {
+    pub kind: GDError,
+    pub source: Option<ErrorSource>,
+    pub backtrace: Option<std::backtrace::Backtrace>,
+}
+
+impl From<GDError> for GDRichError {
+    fn from(value: GDError) -> Self {
+        let backtrace = Some(backtrace::Backtrace::capture());
+        Self {
+            kind: value,
+            source: None,
+            backtrace,
+        }
+    }
+}
+
+impl PartialEq for GDRichError {
+    fn eq(&self, other: &Self) -> bool { self.kind == other.kind }
+}
+
+impl Error for GDRichError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> { self.source.as_ref().map(Box::as_ref) }
+}
+
+impl fmt::Debug for GDRichError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{:?}", self.kind)?;
+        if let Some(source) = &self.source {
+            writeln!(f, "{:?}", source)?;
+        }
+        if let Some(backtrace) = &self.backtrace {
+            writeln!(f, "{:#?}", backtrace)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for GDRichError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { write!(f, "{:?}", self) }
+}
+
+impl GDRichError {
+    /// Create a new rich error (with automatic backtrace)
+    pub fn new(kind: GDError, source: Option<ErrorSource>) -> Self {
+        let backtrace = Some(std::backtrace::Backtrace::capture());
+        Self {
+            kind,
+            source,
+            backtrace,
+        }
+    }
+    // Helpers for creating specific kinds of Rich Errors
+    pub fn packet_underflow(source: Option<ErrorSource>) -> Self { Self::new(GDError::PacketUnderflow, source) }
+    pub fn packet_bad(source: Option<ErrorSource>) -> Self { Self::new(GDError::PacketBad, source) }
+    pub fn protocol_format(source: Option<ErrorSource>) -> Self { Self::new(GDError::ProtocolFormat, source) }
+    pub fn unknown_enum_cast(source: Option<ErrorSource>) -> Self { Self::new(GDError::UnknownEnumCast, source) }
+    pub fn invalid_input(source: Option<ErrorSource>) -> Self { Self::new(GDError::InvalidInput, source) }
+    pub fn decompress(source: Option<ErrorSource>) -> Self { Self::new(GDError::Decompress, source) }
+    pub fn type_parse(source: Option<ErrorSource>) -> Self { Self::new(GDError::TypeParse, source) }
+
+    // Helpers for converting source types, these were added as needed feel free to
+    // add your own
+    pub fn packet_underflow_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::packet_underflow(Some(source.into()))
+    }
+    pub fn packet_bad_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::packet_bad(Some(source.into()))
+    }
+    pub fn protocol_format_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::protocol_format(Some(source.into()))
+    }
+    pub fn unknown_enum_cast_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::unknown_enum_cast(Some(source.into()))
+    }
+    pub fn invalid_input_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::invalid_input(Some(source.into()))
+    }
+    pub fn decompress_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::decompress(Some(source.into()))
+    }
+    pub fn type_parse_from_into<E: Into<Box<dyn std::error::Error + 'static>>>(source: E) -> Self {
+        Self::type_parse(Some(source.into()))
+    }
 }
 
 #[cfg(test)]
@@ -61,7 +154,7 @@ mod tests {
     // Testing Err variant of the GDResult type
     #[test]
     fn test_gdresult_err() {
-        let result: GDResult<u32> = Err(GDError::InvalidInput);
+        let result: GDResult<u32> = Err(GDError::InvalidInput.into());
         assert!(result.is_err());
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,7 +47,8 @@ impl GDErrorKind {
     /// backtrace)
     ///
     /// ```
-    /// thing.parse().map_err(|e| GDErrorKind::TypeParse.context(e))
+    /// use gamedig::{GDErrorKind, GDResult};
+    /// let _: GDResult<u32> = "thing".parse().map_err(|e| GDErrorKind::TypeParse.context(e));
     /// ```
     pub fn context<E: Into<Box<dyn std::error::Error + 'static>>>(self, source: E) -> GDError {
         GDError::from_error(self, source)
@@ -62,18 +63,25 @@ type ErrorSource = Box<dyn std::error::Error + 'static>;
 /// backtrace):
 ///
 /// Directly from an [error kind](crate::errors::GDErrorKind) (without a source)
+///
 /// ```
-/// GDErrorKind::PacketBad.into()
+/// use gamedig::{GDError, GDErrorKind};
+/// let _: GDError = GDErrorKind::PacketBad.into();
 /// ```
 ///
 /// [From an error kind with a source](crate::errors::GDErrorKind::context) (any
-/// type that implements `Into<Box<dyn std::error::Error + 'static>>) ```
-/// GDErrorKind::PacketBad.context("Reason the packet was bad")
+/// type that implements `Into<Box<dyn std::error::Error + 'static>>)
+///
 /// ```
-/// 
+/// use gamedig::{GDError, GDErrorKind};
+/// let _: GDError = GDErrorKind::PacketBad.context("Reason the packet was bad");
+/// ```
+///
 /// Using the [new helper](crate::errors::GDError::new)
+///
 /// ```
-/// GDError::new(GDErrorKind::PacketBad, "Reason the packet was bad")
+/// use gamedig::{GDError, GDErrorKind};
+/// let _: GDError = GDError::new(GDErrorKind::PacketBad, Some("Reason the packet was bad".into()));
 /// ```
 pub struct GDError {
     pub kind: GDErrorKind,
@@ -152,20 +160,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // Testing the Display trait for the GDErrorKind type
-    #[test]
-    fn test_display() {
-        let error = GDErrorKind::PacketOverflow;
-        assert_eq!(format!("{}", error), "PacketOverflow");
-    }
-
-    // Testing the Error trait for the GDErrorKind type
-    #[test]
-    fn test_error_trait() {
-        let error = GDErrorKind::PacketBad;
-        assert!(error.source().is_none());
-    }
-
     // Testing cloning the GDErrorKind type
     #[test]
     fn test_cloning() {
@@ -173,4 +167,7 @@ mod tests {
         let cloned_error = error.clone();
         assert_eq!(error, cloned_error);
     }
+
+    // TODO: test display GDError
+    // TODO: test error trait GDError
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -110,13 +110,15 @@ impl Error for GDError {
 
 impl fmt::Debug for GDError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{:?}", self.kind)?;
+        writeln!(f, "GDError{{ kind={:?}", self.kind)?;
         if let Some(source) = &self.source {
-            writeln!(f, "{:?}", source)?;
+            writeln!(f, "  source={:?}", source)?;
         }
         if let Some(backtrace) = &self.backtrace {
-            writeln!(f, "{:#?}", backtrace)?;
+            let bt = format!("{:#?}", backtrace);
+            writeln!(f, "  backtrace={}", bt.replace('\n', "\n  "))?;
         }
+        writeln!(f, "}}")?;
         Ok(())
     }
 }

--- a/src/games/bat1944.rs
+++ b/src/games/bat1944.rs
@@ -15,12 +15,12 @@ pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
 
     if let Some(rules) = &mut valve_response.rules {
         if let Some(bat_max_players) = rules.get("bat_max_players_i") {
-            valve_response.info.players_maximum = bat_max_players.parse().map_err(|_| TypeParse)?;
+            valve_response.info.players_maximum = bat_max_players.parse().map_err(|e| TypeParse.context(e))?;
             rules.remove("bat_max_players_i");
         }
 
         if let Some(bat_player_count) = rules.get("bat_player_count_s") {
-            valve_response.info.players_online = bat_player_count.parse().map_err(|_| TypeParse)?;
+            valve_response.info.players_online = bat_player_count.parse().map_err(|e| TypeParse.context(e))?;
             rules.remove("bat_player_count_s");
         }
 

--- a/src/games/bat1944.rs
+++ b/src/games/bat1944.rs
@@ -1,6 +1,6 @@
 use crate::{
     protocols::valve::{self, game, SteamApp},
-    GDError::TypeParse,
+    GDErrorKind::TypeParse,
     GDResult,
 };
 use std::net::{IpAddr, SocketAddr};

--- a/src/games/jc2mp.rs
+++ b/src/games/jc2mp.rs
@@ -94,20 +94,20 @@ pub fn query_with_timeout(
     let packets = client.get_server_packets()?;
     let data = packets
         .get(0)
-        .ok_or(PacketBad.rich("First packet missing"))?;
+        .ok_or(PacketBad.context("First packet missing"))?;
 
     let (mut server_vars, remaining_data) = data_to_map(data)?;
     let players = parse_players_and_teams(remaining_data)?;
 
     let players_maximum = server_vars
         .remove("maxplayers")
-        .ok_or(PacketBad.rich("Server variables missing maxplayers"))?
+        .ok_or(PacketBad.context("Server variables missing maxplayers"))?
         .parse()
-        .map_err(|e| TypeParse.rich(e))?;
+        .map_err(|e| TypeParse.context(e))?;
     let players_online = match server_vars.remove("numplayers") {
         None => players.len(),
         Some(v) => {
-            let reported_players = v.parse().map_err(|e| TypeParse.rich(e))?;
+            let reported_players = v.parse().map_err(|e| TypeParse.context(e))?;
             match reported_players < players.len() {
                 true => players.len(),
                 false => reported_players,

--- a/src/games/jc2mp.rs
+++ b/src/games/jc2mp.rs
@@ -3,7 +3,8 @@ use crate::protocols::gamespy::common::has_password;
 use crate::protocols::gamespy::three::{data_to_map, GameSpy3};
 use crate::protocols::types::{CommonPlayer, CommonResponse, GenericPlayer, TimeoutSettings};
 use crate::protocols::GenericResponse;
-use crate::{GDError, GDResult, GDRichError};
+use crate::GDError::{PacketBad, TypeParse};
+use crate::{GDError, GDResult};
 use byteorder::BigEndian;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -93,20 +94,20 @@ pub fn query_with_timeout(
     let packets = client.get_server_packets()?;
     let data = packets
         .get(0)
-        .ok_or(GDRichError::packet_bad_from_into("First packet missing"))?;
+        .ok_or(PacketBad.rich("First packet missing"))?;
 
     let (mut server_vars, remaining_data) = data_to_map(data)?;
     let players = parse_players_and_teams(remaining_data)?;
 
     let players_maximum = server_vars
         .remove("maxplayers")
-        .ok_or(GDRichError::packet_bad(None))?
+        .ok_or(PacketBad.rich("Server variables missing maxplayers"))?
         .parse()
-        .map_err(GDRichError::type_parse_from_into)?;
+        .map_err(|e| TypeParse.rich(e))?;
     let players_online = match server_vars.remove("numplayers") {
         None => players.len(),
         Some(v) => {
-            let reported_players = v.parse().map_err(GDRichError::type_parse_from_into)?;
+            let reported_players = v.parse().map_err(|e| TypeParse.rich(e))?;
             match reported_players < players.len() {
                 true => players.len(),
                 false => reported_players,

--- a/src/games/jc2mp.rs
+++ b/src/games/jc2mp.rs
@@ -3,8 +3,8 @@ use crate::protocols::gamespy::common::has_password;
 use crate::protocols::gamespy::three::{data_to_map, GameSpy3};
 use crate::protocols::types::{CommonPlayer, CommonResponse, GenericPlayer, TimeoutSettings};
 use crate::protocols::GenericResponse;
-use crate::GDError::{PacketBad, TypeParse};
-use crate::{GDError, GDResult};
+use crate::GDErrorKind::{PacketBad, TypeParse};
+use crate::{GDErrorKind, GDResult};
 use byteorder::BigEndian;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -116,11 +116,15 @@ pub fn query_with_timeout(
     };
 
     Ok(Response {
-        version: server_vars.remove("version").ok_or(GDError::PacketBad)?,
+        version: server_vars
+            .remove("version")
+            .ok_or(GDErrorKind::PacketBad)?,
         description: server_vars
             .remove("description")
-            .ok_or(GDError::PacketBad)?,
-        name: server_vars.remove("hostname").ok_or(GDError::PacketBad)?,
+            .ok_or(GDErrorKind::PacketBad)?,
+        name: server_vars
+            .remove("hostname")
+            .ok_or(GDErrorKind::PacketBad)?,
         has_password: has_password(&mut server_vars)?,
         players,
         players_maximum,

--- a/src/games/mc.rs
+++ b/src/games/mc.rs
@@ -20,7 +20,7 @@ pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
         return Ok(response);
     }
 
-    Err(GDError::AutoQuery)
+    Err(GDError::AutoQuery.into())
 }
 
 /// Query a Java Server.

--- a/src/games/mc.rs
+++ b/src/games/mc.rs
@@ -1,6 +1,6 @@
 use crate::{
     protocols::minecraft::{self, BedrockResponse, JavaResponse, LegacyGroup},
-    GDError,
+    GDErrorKind,
     GDResult,
 };
 use std::net::{IpAddr, SocketAddr};
@@ -20,7 +20,7 @@ pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
         return Ok(response);
     }
 
-    Err(GDError::AutoQuery.into())
+    Err(GDErrorKind::AutoQuery.into())
 }
 
 /// Query a Java Server.

--- a/src/protocols/gamespy/common.rs
+++ b/src/protocols/gamespy/common.rs
@@ -1,4 +1,4 @@
-use crate::{GDError, GDResult};
+use crate::{GDError, GDResult, GDRichError};
 use std::collections::HashMap;
 
 pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool> {
@@ -11,7 +11,9 @@ pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool>
         return Ok(has);
     }
 
-    let as_numeral: u8 = password_value.parse().map_err(|_| GDError::TypeParse)?;
+    let as_numeral: u8 = password_value
+        .parse()
+        .map_err(GDRichError::type_parse_from_into)?;
 
     Ok(as_numeral != 0)
 }

--- a/src/protocols/gamespy/common.rs
+++ b/src/protocols/gamespy/common.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool> {
     let password_value = server_vars
         .remove("password")
-        .ok_or(GDErrorKind::PacketBad.rich("Missing password (exists) field"))?
+        .ok_or(GDErrorKind::PacketBad.context("Missing password (exists) field"))?
         .to_lowercase();
 
     if let Ok(has) = password_value.parse::<bool>() {
@@ -13,7 +13,7 @@ pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool>
 
     let as_numeral: u8 = password_value
         .parse()
-        .map_err(|e| GDErrorKind::TypeParse.rich(e))?;
+        .map_err(|e| GDErrorKind::TypeParse.context(e))?;
 
     Ok(as_numeral != 0)
 }

--- a/src/protocols/gamespy/common.rs
+++ b/src/protocols/gamespy/common.rs
@@ -1,10 +1,10 @@
-use crate::{GDError, GDResult};
+use crate::{GDErrorKind, GDResult};
 use std::collections::HashMap;
 
 pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool> {
     let password_value = server_vars
         .remove("password")
-        .ok_or(GDError::PacketBad.rich("Missing password (exists) field"))?
+        .ok_or(GDErrorKind::PacketBad.rich("Missing password (exists) field"))?
         .to_lowercase();
 
     if let Ok(has) = password_value.parse::<bool>() {
@@ -13,7 +13,7 @@ pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool>
 
     let as_numeral: u8 = password_value
         .parse()
-        .map_err(|e| GDError::TypeParse.rich(e))?;
+        .map_err(|e| GDErrorKind::TypeParse.rich(e))?;
 
     Ok(as_numeral != 0)
 }

--- a/src/protocols/gamespy/common.rs
+++ b/src/protocols/gamespy/common.rs
@@ -1,10 +1,10 @@
-use crate::{GDError, GDResult, GDRichError};
+use crate::{GDError, GDResult};
 use std::collections::HashMap;
 
 pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool> {
     let password_value = server_vars
         .remove("password")
-        .ok_or(GDError::PacketBad)?
+        .ok_or(GDError::PacketBad.rich("Missing password (exists) field"))?
         .to_lowercase();
 
     if let Ok(has) = password_value.parse::<bool>() {
@@ -13,7 +13,7 @@ pub fn has_password(server_vars: &mut HashMap<String, String>) -> GDResult<bool>
 
     let as_numeral: u8 = password_value
         .parse()
-        .map_err(GDRichError::type_parse_from_into)?;
+        .map_err(|e| GDError::TypeParse.rich(e))?;
 
     Ok(as_numeral != 0)
 }

--- a/src/protocols/gamespy/protocols/one/protocol.rs
+++ b/src/protocols/gamespy/protocols/one/protocol.rs
@@ -61,10 +61,10 @@ fn get_server_values(
         if let Some(qid) = query_data {
             let split: Vec<&str> = qid.split('.').collect();
 
-            query_id = Some(split[0].parse().map_err(|e| TypeParse.rich(e))?);
+            query_id = Some(split[0].parse().map_err(|e| TypeParse.context(e))?);
             match split.len() {
                 1 => (),
-                2 => part = split[1].parse().map_err(|e| TypeParse.rich(e))?,
+                2 => part = split[1].parse().map_err(|e| TypeParse.context(e))?,
                 _ => Err(GDErrorKind::PacketBad)?, /* the queryid can't be splitted in more than 2
                                                     * elements */
             };
@@ -139,13 +139,13 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
                 .ok_or(GDErrorKind::PacketBad)?
                 .trim()
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             ping: player_data
                 .get("ping")
                 .ok_or(GDErrorKind::PacketBad)?
                 .trim()
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             face: player_data
                 .get("face")
                 .ok_or(GDErrorKind::PacketBad)?
@@ -163,13 +163,13 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
                 .ok_or(GDErrorKind::PacketBad)?
                 .trim()
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             deaths: match player_data.get("deaths") {
-                Some(v) => Some(v.trim().parse().map_err(|e| TypeParse.rich(e))?),
+                Some(v) => Some(v.trim().parse().map_err(|e| TypeParse.context(e))?),
                 None => None,
             },
             health: match player_data.get("health") {
-                Some(v) => Some(v.trim().parse().map_err(|e| TypeParse.rich(e))?),
+                Some(v) => Some(v.trim().parse().map_err(|e| TypeParse.context(e))?),
                 None => None,
             },
             secret: player_data
@@ -177,7 +177,7 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
                 .ok_or(GDErrorKind::PacketBad)?
                 .to_lowercase()
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
         };
 
         players.push(new_player);
@@ -205,10 +205,10 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
         .remove("maxplayers")
         .ok_or(GDErrorKind::PacketBad)?
         .parse()
-        .map_err(|e| TypeParse.rich(e))?;
+        .map_err(|e| TypeParse.context(e))?;
     let players_minimum = match server_vars.remove("minplayers") {
         None => None,
-        Some(v) => Some(v.parse::<u8>().map_err(|e| TypeParse.rich(e))?),
+        Some(v) => Some(v.parse::<u8>().map_err(|e| TypeParse.context(e))?),
     };
 
     let players = extract_players(&mut server_vars, players_maximum)?;
@@ -241,7 +241,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
             .unwrap_or_else(|| "true".to_string())
             .to_lowercase()
             .parse()
-            .map_err(|e| TypeParse.rich(e))?,
+            .map_err(|e| TypeParse.context(e))?,
         unused_entries: server_vars,
     })
 }

--- a/src/protocols/gamespy/protocols/three/protocol.rs
+++ b/src/protocols/gamespy/protocols/three/protocol.rs
@@ -81,11 +81,11 @@ impl GameSpy3 {
         let mut buf = Buffer::<BigEndian>::new(&received);
 
         if buf.read::<u8>()? != kind {
-            return Err(PacketBad.rich("Kind of packet did not match"));
+            return Err(PacketBad.context("Kind of packet did not match"));
         }
 
         if buf.read::<u32>()? != THIS_SESSION_ID {
-            return Err(PacketBad.rich("Session ID did not match"));
+            return Err(PacketBad.context("Session ID did not match"));
         }
 
         Ok(buf.remaining_bytes().to_vec())
@@ -107,7 +107,9 @@ impl GameSpy3 {
         let mut buf = Buffer::<LittleEndian>::new(&data);
 
         let challenge_as_string = buf.read_string::<Utf8Decoder>(None)?;
-        let challenge = challenge_as_string.parse().map_err(|e| TypeParse.rich(e))?;
+        let challenge = challenge_as_string
+            .parse()
+            .map_err(|e| TypeParse.context(e))?;
 
         Ok(match challenge == 0 {
             true => None,
@@ -146,7 +148,7 @@ impl GameSpy3 {
             }
 
             if buf.read_string::<Utf8Decoder>(None)? != "splitnum" {
-                return Err(PacketBad.rich("Expected string \"splitnum\""));
+                return Err(PacketBad.context("Expected string \"splitnum\""));
             }
 
             let id = buf.read::<u8>()?;
@@ -166,7 +168,7 @@ impl GameSpy3 {
         }
 
         if values.iter().any(|v| v.is_empty()) {
-            return Err(PacketBad.rich("One (or more) packets is empty"));
+            return Err(PacketBad.context("One (or more) packets is empty"));
         }
 
         Ok(values)
@@ -288,27 +290,27 @@ fn parse_players_and_teams(packets: Vec<Vec<u8>>) -> GDResult<(Vec<Player>, Vec<
                 .get("score")
                 .ok_or(GDErrorKind::PacketBad)?
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             ping: player_data
                 .get("ping")
                 .ok_or(GDErrorKind::PacketBad)?
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             team: player_data
                 .get("team")
                 .ok_or(GDErrorKind::PacketBad)?
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             deaths: player_data
                 .get("deaths")
                 .ok_or(GDErrorKind::PacketBad)?
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
             skill: player_data
                 .get("skill")
                 .ok_or(GDErrorKind::PacketBad)?
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
         })
     }
 
@@ -327,7 +329,7 @@ fn parse_players_and_teams(packets: Vec<Vec<u8>>) -> GDResult<(Vec<Player>, Vec<
                 .get("score")
                 .ok_or(GDErrorKind::PacketBad)?
                 .parse()
-                .map_err(|e| TypeParse.rich(e))?,
+                .map_err(|e| TypeParse.context(e))?,
         })
     }
 
@@ -351,15 +353,15 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
         .remove("maxplayers")
         .ok_or(GDErrorKind::PacketBad)?
         .parse()
-        .map_err(|e| TypeParse.rich(e))?;
+        .map_err(|e| TypeParse.context(e))?;
     let players_minimum = match server_vars.remove("minplayers") {
         None => None,
-        Some(v) => Some(v.parse::<u8>().map_err(|e| TypeParse.rich(e))?),
+        Some(v) => Some(v.parse::<u8>().map_err(|e| TypeParse.context(e))?),
     };
     let players_online = match server_vars.remove("numplayers") {
         None => players.len(),
         Some(v) => {
-            let reported_players = v.parse().map_err(|e| TypeParse.rich(e))?;
+            let reported_players = v.parse().map_err(|e| TypeParse.context(e))?;
             match reported_players < players.len() {
                 true => players.len(),
                 false => reported_players,
@@ -391,7 +393,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
             .unwrap_or_else(|| "true".to_string())
             .to_lowercase()
             .parse()
-            .map_err(|e| TypeParse.rich(e))?,
+            .map_err(|e| TypeParse.context(e))?,
         unused_entries: server_vars,
     })
 }

--- a/src/protocols/gamespy/protocols/two/protocol.rs
+++ b/src/protocols/gamespy/protocols/two/protocol.rs
@@ -2,7 +2,7 @@ use crate::buffer::{Buffer, Utf8Decoder};
 use crate::protocols::gamespy::two::{Player, Response, Team};
 use crate::protocols::types::TimeoutSettings;
 use crate::socket::{Socket, UdpSocket};
-use crate::{GDError, GDResult};
+use crate::{GDError, GDResult, GDRichError};
 use byteorder::BigEndian;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -25,7 +25,7 @@ macro_rules! table_extract_parse {
     ($table:expr, $name:literal, $index:expr) => {
         table_extract!($table, $name, $index)
             .parse()
-            .map_err(|_| GDError::PacketBad)?
+            .map_err(GDRichError::packet_bad_from_into)?
     };
 }
 
@@ -87,7 +87,7 @@ impl GameSpy2 {
 
         let mut buf = Buffer::<BigEndian>::new(&received);
         if buf.read::<u8>()? != 0 || buf.read::<u32>()? != 1 {
-            return Err(GDError::PacketBad);
+            return Err(GDRichError::packet_bad(None));
         }
 
         let buf_index = buf.current_position();
@@ -163,7 +163,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
     let players_online = match server_vars.remove("numplayers") {
         None => players.len(),
         Some(v) => {
-            let reported_players = v.parse().map_err(|_| GDError::TypeParse)?;
+            let reported_players = v.parse().map_err(GDRichError::type_parse_from_into)?;
             match reported_players < players.len() {
                 true => players.len(),
                 false => reported_players,
@@ -172,7 +172,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
     };
     let players_minimum = match server_vars.remove("minplayers") {
         None => None,
-        Some(v) => Some(v.parse::<u8>().map_err(|_| GDError::TypeParse)?),
+        Some(v) => Some(v.parse::<u8>().map_err(GDRichError::type_parse_from_into)?),
     };
 
     Ok(Response {
@@ -184,7 +184,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
             .remove("maxplayers")
             .ok_or(GDError::PacketBad)?
             .parse()
-            .map_err(|_| GDError::PacketBad)?,
+            .map_err(GDRichError::packet_bad_from_into)?,
         players_online,
         players_minimum,
         players,

--- a/src/protocols/gamespy/protocols/two/protocol.rs
+++ b/src/protocols/gamespy/protocols/two/protocol.rs
@@ -26,7 +26,7 @@ macro_rules! table_extract_parse {
     ($table:expr, $name:literal, $index:expr) => {
         table_extract!($table, $name, $index)
             .parse()
-            .map_err(|e| PacketBad.rich(e))?
+            .map_err(|e| PacketBad.context(e))?
     };
 }
 
@@ -167,7 +167,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
     let players_online = match server_vars.remove("numplayers") {
         None => players.len(),
         Some(v) => {
-            let reported_players = v.parse().map_err(|e| TypeParse.rich(e))?;
+            let reported_players = v.parse().map_err(|e| TypeParse.context(e))?;
             match reported_players < players.len() {
                 true => players.len(),
                 false => reported_players,
@@ -176,7 +176,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
     };
     let players_minimum = match server_vars.remove("minplayers") {
         None => None,
-        Some(v) => Some(v.parse::<u8>().map_err(|e| TypeParse.rich(e))?),
+        Some(v) => Some(v.parse::<u8>().map_err(|e| TypeParse.context(e))?),
     };
 
     Ok(Response {
@@ -188,7 +188,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
             .remove("maxplayers")
             .ok_or(PacketBad)?
             .parse()
-            .map_err(|e| TypeParse.rich(e))?,
+            .map_err(|e| TypeParse.context(e))?,
         players_online,
         players_minimum,
         players,

--- a/src/protocols/minecraft/protocol/bedrock.rs
+++ b/src/protocols/minecraft/protocol/bedrock.rs
@@ -46,12 +46,12 @@ impl Bedrock {
         let mut buffer = Buffer::<LittleEndian>::new(&received);
 
         if buffer.read::<u8>()? != 0x1c {
-            return Err(PacketBad.rich("Expected 0x1c"));
+            return Err(PacketBad.context("Expected 0x1c"));
         }
 
         // Checking for our nonce directly from a u64 (as the nonce is 8 bytes).
         if buffer.read::<u64>()? != 9833440827789222417 {
-            return Err(PacketBad.rich("Invalid nonce"));
+            return Err(PacketBad.context("Invalid nonce"));
         }
 
         // These 8 bytes are identical to the serverId string we receive in decimal
@@ -60,11 +60,11 @@ impl Bedrock {
 
         // Verifying the magic value (as we need 16 bytes, cast to two u64 values)
         if buffer.read::<u64>()? != 18374403896610127616 {
-            return Err(PacketBad.rich("Invalid magic"));
+            return Err(PacketBad.context("Invalid magic"));
         }
 
         if buffer.read::<u64>()? != 8671175388723805693 {
-            return Err(PacketBad.rich("Invalid magic"));
+            return Err(PacketBad.context("Invalid magic"));
         }
 
         let remaining_length = buffer.switch_endian_chunk(2)?.read::<u16>()? as usize;
@@ -76,7 +76,7 @@ impl Bedrock {
 
         // We must have at least 6 values
         if status.len() < 6 {
-            return Err(PacketBad.rich("Not enough values"));
+            return Err(PacketBad.context("Not enough values"));
         }
 
         Ok(BedrockResponse {

--- a/src/protocols/minecraft/protocol/bedrock.rs
+++ b/src/protocols/minecraft/protocol/bedrock.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     socket::{Socket, UdpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, TypeParse},
+    GDErrorKind::{PacketBad, TypeParse},
     GDResult,
 };
 

--- a/src/protocols/minecraft/protocol/bedrock.rs
+++ b/src/protocols/minecraft/protocol/bedrock.rs
@@ -84,8 +84,8 @@ impl Bedrock {
             name: status[1].to_string(),
             version_name: status[3].to_string(),
             version_protocol: status[2].to_string(),
-            players_maximum: status[5].parse().map_err(|_| TypeParse)?,
-            players_online: status[4].parse().map_err(|_| TypeParse)?,
+            players_maximum: status[5].parse().map_err(|e| TypeParse.context(e))?,
+            players_online: status[4].parse().map_err(|e| TypeParse.context(e))?,
             id: status.get(6).map(|v| v.to_string()),
             map: status.get(7).map(|v| v.to_string()),
             game_mode: match status.get(8) {

--- a/src/protocols/minecraft/protocol/java.rs
+++ b/src/protocols/minecraft/protocol/java.rs
@@ -7,7 +7,6 @@ use crate::{
     socket::{Socket, TcpSocket},
     GDError::{JsonParse, PacketBad},
     GDResult,
-    GDRichError,
 };
 
 use std::net::SocketAddr;
@@ -91,7 +90,7 @@ impl Java {
 
         if get_varint(&mut buffer)? != 0 {
             // first var int is the packet id
-            return Err(GDRichError::packet_bad_from_into("Expected 0"));
+            return Err(PacketBad.rich("Expected 0"));
         }
 
         let json_response = get_string(&mut buffer)?;

--- a/src/protocols/minecraft/protocol/java.rs
+++ b/src/protocols/minecraft/protocol/java.rs
@@ -7,6 +7,7 @@ use crate::{
     socket::{Socket, TcpSocket},
     GDError::{JsonParse, PacketBad},
     GDResult,
+    GDRichError,
 };
 
 use std::net::SocketAddr;
@@ -90,7 +91,7 @@ impl Java {
 
         if get_varint(&mut buffer)? != 0 {
             // first var int is the packet id
-            return Err(PacketBad);
+            return Err(GDRichError::packet_bad_from_into("Expected 0"));
         }
 
         let json_response = get_string(&mut buffer)?;

--- a/src/protocols/minecraft/protocol/java.rs
+++ b/src/protocols/minecraft/protocol/java.rs
@@ -94,7 +94,7 @@ impl Java {
         }
 
         let json_response = get_string(&mut buffer)?;
-        let value_response: Value = serde_json::from_str(&json_response).map_err(|_| JsonParse)?;
+        let value_response: Value = serde_json::from_str(&json_response).map_err(|e| JsonParse.context(e))?;
 
         let version_name = value_response["version"]["name"]
             .as_str()

--- a/src/protocols/minecraft/protocol/java.rs
+++ b/src/protocols/minecraft/protocol/java.rs
@@ -90,7 +90,7 @@ impl Java {
 
         if get_varint(&mut buffer)? != 0 {
             // first var int is the packet id
-            return Err(PacketBad.rich("Expected 0"));
+            return Err(PacketBad.context("Expected 0"));
         }
 
         let json_response = get_string(&mut buffer)?;

--- a/src/protocols/minecraft/protocol/java.rs
+++ b/src/protocols/minecraft/protocol/java.rs
@@ -5,7 +5,7 @@ use crate::{
         types::TimeoutSettings,
     },
     socket::{Socket, TcpSocket},
-    GDError::{JsonParse, PacketBad},
+    GDErrorKind::{JsonParse, PacketBad},
     GDResult,
 };
 

--- a/src/protocols/minecraft/protocol/legacy_bv1_8.rs
+++ b/src/protocols/minecraft/protocol/legacy_bv1_8.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, ProtocolFormat},
+    GDError::PacketBad,
     GDResult,
+    GDRichError,
 };
 
 use std::net::SocketAddr;
@@ -35,7 +36,7 @@ impl LegacyBV1_8 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(ProtocolFormat);
+            return Err(GDRichError::protocol_format_from_into("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;

--- a/src/protocols/minecraft/protocol/legacy_bv1_8.rs
+++ b/src/protocols/minecraft/protocol/legacy_bv1_8.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, ProtocolFormat},
+    GDErrorKind::{PacketBad, ProtocolFormat},
     GDResult,
 };
 

--- a/src/protocols/minecraft/protocol/legacy_bv1_8.rs
+++ b/src/protocols/minecraft/protocol/legacy_bv1_8.rs
@@ -47,8 +47,8 @@ impl LegacyBV1_8 {
         error_by_expected_size(3, split.len())?;
 
         let description = split[0].to_string();
-        let online_players = split[1].parse().map_err(|_| PacketBad)?;
-        let max_players = split[2].parse().map_err(|_| PacketBad)?;
+        let online_players = split[1].parse().map_err(|e| PacketBad.context(e))?;
+        let max_players = split[2].parse().map_err(|e| PacketBad.context(e))?;
 
         Ok(JavaResponse {
             version_name: "Beta 1.8+".to_string(),

--- a/src/protocols/minecraft/protocol/legacy_bv1_8.rs
+++ b/src/protocols/minecraft/protocol/legacy_bv1_8.rs
@@ -35,7 +35,7 @@ impl LegacyBV1_8 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(ProtocolFormat.rich("Expected 0xFF"));
+            return Err(ProtocolFormat.context("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;

--- a/src/protocols/minecraft/protocol/legacy_bv1_8.rs
+++ b/src/protocols/minecraft/protocol/legacy_bv1_8.rs
@@ -6,9 +6,8 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::PacketBad,
+    GDError::{PacketBad, ProtocolFormat},
     GDResult,
-    GDRichError,
 };
 
 use std::net::SocketAddr;
@@ -36,7 +35,7 @@ impl LegacyBV1_8 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(GDRichError::protocol_format_from_into("Expected 0xFF"));
+            return Err(ProtocolFormat.rich("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;

--- a/src/protocols/minecraft/protocol/legacy_v1_4.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_4.rs
@@ -8,8 +8,9 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, ProtocolFormat},
+    GDError::PacketBad,
     GDResult,
+    GDRichError,
 };
 use std::net::SocketAddr;
 
@@ -34,7 +35,7 @@ impl LegacyV1_4 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(ProtocolFormat);
+            return Err(GDRichError::protocol_format_from_into("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;

--- a/src/protocols/minecraft/protocol/legacy_v1_4.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_4.rs
@@ -8,9 +8,8 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::PacketBad,
+    GDError::{PacketBad, ProtocolFormat},
     GDResult,
-    GDRichError,
 };
 use std::net::SocketAddr;
 
@@ -35,7 +34,7 @@ impl LegacyV1_4 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(GDRichError::protocol_format_from_into("Expected 0xFF"));
+            return Err(ProtocolFormat.rich("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;

--- a/src/protocols/minecraft/protocol/legacy_v1_4.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_4.rs
@@ -34,7 +34,7 @@ impl LegacyV1_4 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(ProtocolFormat.rich("Expected 0xFF"));
+            return Err(ProtocolFormat.context("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;

--- a/src/protocols/minecraft/protocol/legacy_v1_4.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_4.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, ProtocolFormat},
+    GDErrorKind::{PacketBad, ProtocolFormat},
     GDResult,
 };
 use std::net::SocketAddr;

--- a/src/protocols/minecraft/protocol/legacy_v1_4.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_4.rs
@@ -50,8 +50,8 @@ impl LegacyV1_4 {
         error_by_expected_size(3, split.len())?;
 
         let description = split[0].to_string();
-        let online_players = split[1].parse().map_err(|_| PacketBad)?;
-        let max_players = split[2].parse().map_err(|_| PacketBad)?;
+        let online_players = split[1].parse().map_err(|e| PacketBad.context(e))?;
+        let max_players = split[2].parse().map_err(|e| PacketBad.context(e))?;
 
         Ok(JavaResponse {
             version_name: "1.4+".to_string(),

--- a/src/protocols/minecraft/protocol/legacy_v1_6.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_6.rs
@@ -55,17 +55,17 @@ impl LegacyV1_6 {
         let version_protocol = buffer
             .read_string::<Utf16Decoder<BigEndian>>(None)?
             .parse()
-            .map_err(|_| PacketBad)?;
+            .map_err(|e| PacketBad.context(e))?;
         let version_name = buffer.read_string::<Utf16Decoder<BigEndian>>(None)?;
         let description = buffer.read_string::<Utf16Decoder<BigEndian>>(None)?;
         let online_players = buffer
             .read_string::<Utf16Decoder<BigEndian>>(None)?
             .parse()
-            .map_err(|_| PacketBad)?;
+            .map_err(|e| PacketBad.context(e))?;
         let max_players = buffer
             .read_string::<Utf16Decoder<BigEndian>>(None)?
             .parse()
-            .map_err(|_| PacketBad)?;
+            .map_err(|e| PacketBad.context(e))?;
 
         Ok(JavaResponse {
             version_name,

--- a/src/protocols/minecraft/protocol/legacy_v1_6.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_6.rs
@@ -8,8 +8,9 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, ProtocolFormat},
+    GDError::PacketBad,
     GDResult,
+    GDRichError,
 };
 use std::net::SocketAddr;
 
@@ -88,14 +89,16 @@ impl LegacyV1_6 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(ProtocolFormat);
+            return Err(GDRichError::protocol_format_from_into("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;
         error_by_expected_size((length + 3) as usize, data.len())?;
 
         if !LegacyV1_6::is_protocol(&mut buffer)? {
-            return Err(ProtocolFormat);
+            return Err(GDRichError::protocol_format_from_into(
+                "Not legacy 1.6 protocol",
+            ));
         }
 
         LegacyV1_6::get_response(&mut buffer)

--- a/src/protocols/minecraft/protocol/legacy_v1_6.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_6.rs
@@ -88,14 +88,14 @@ impl LegacyV1_6 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(ProtocolFormat.rich("Expected 0xFF"));
+            return Err(ProtocolFormat.context("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;
         error_by_expected_size((length + 3) as usize, data.len())?;
 
         if !LegacyV1_6::is_protocol(&mut buffer)? {
-            return Err(ProtocolFormat.rich("Not legacy 1.6 protocol"));
+            return Err(ProtocolFormat.context("Not legacy 1.6 protocol"));
         }
 
         LegacyV1_6::get_response(&mut buffer)

--- a/src/protocols/minecraft/protocol/legacy_v1_6.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_6.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::{PacketBad, ProtocolFormat},
+    GDErrorKind::{PacketBad, ProtocolFormat},
     GDResult,
 };
 use std::net::SocketAddr;

--- a/src/protocols/minecraft/protocol/legacy_v1_6.rs
+++ b/src/protocols/minecraft/protocol/legacy_v1_6.rs
@@ -8,9 +8,8 @@ use crate::{
     },
     socket::{Socket, TcpSocket},
     utils::error_by_expected_size,
-    GDError::PacketBad,
+    GDError::{PacketBad, ProtocolFormat},
     GDResult,
-    GDRichError,
 };
 use std::net::SocketAddr;
 
@@ -89,16 +88,14 @@ impl LegacyV1_6 {
         let mut buffer = Buffer::<BigEndian>::new(&data);
 
         if buffer.read::<u8>()? != 0xFF {
-            return Err(GDRichError::protocol_format_from_into("Expected 0xFF"));
+            return Err(ProtocolFormat.rich("Expected 0xFF"));
         }
 
         let length = buffer.read::<u16>()? * 2;
         error_by_expected_size((length + 3) as usize, data.len())?;
 
         if !LegacyV1_6::is_protocol(&mut buffer)? {
-            return Err(GDRichError::protocol_format_from_into(
-                "Not legacy 1.6 protocol",
-            ));
+            return Err(ProtocolFormat.rich("Not legacy 1.6 protocol"));
         }
 
         LegacyV1_6::get_response(&mut buffer)

--- a/src/protocols/minecraft/protocol/mod.rs
+++ b/src/protocols/minecraft/protocol/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         LegacyGroup,
     },
     protocols::types::TimeoutSettings,
-    GDError::AutoQuery,
+    GDErrorKind::AutoQuery,
     GDResult,
 };
 use std::net::SocketAddr;

--- a/src/protocols/minecraft/protocol/mod.rs
+++ b/src/protocols/minecraft/protocol/mod.rs
@@ -38,7 +38,7 @@ pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) ->
         return Ok(response);
     }
 
-    Err(AutoQuery)
+    Err(AutoQuery.into())
 }
 
 /// Query a Java Server.
@@ -60,7 +60,7 @@ pub fn query_legacy(address: &SocketAddr, timeout_settings: Option<TimeoutSettin
         return Ok(response);
     }
 
-    Err(AutoQuery)
+    Err(AutoQuery.into())
 }
 
 /// Query a specific (Java) Legacy Server.

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -175,7 +175,7 @@ impl GameMode {
             "Hardcore" => Ok(GameMode::Hardcore),
             "Spectator" => Ok(GameMode::Spectator),
             "Adventure" => Ok(GameMode::Adventure),
-            _ => Err(UnknownEnumCast.rich(format!("Unknown gamemode {:?}", value))),
+            _ => Err(UnknownEnumCast.context(format!("Unknown gamemode {:?}", value))),
         }
     }
 }
@@ -193,7 +193,7 @@ pub(crate) fn get_varint<B: ByteOrder>(buffer: &mut Buffer<B>) -> GDResult<i32> 
 
         // The 5th byte is only allowed to have the 4 smallest bits set
         if i == 4 && (current_byte & 0xf0 != 0) {
-            return Err(PacketBad.rich("Bad 5th byte"));
+            return Err(PacketBad.context("Bad 5th byte"));
         }
 
         if (current_byte & msb) == 0 {
@@ -236,7 +236,7 @@ pub(crate) fn get_string<B: ByteOrder>(buffer: &mut Buffer<B>) -> GDResult<Strin
         text.push(buffer.read::<u8>()?)
     }
 
-    String::from_utf8(text).map_err(|e| PacketBad.rich(e))
+    String::from_utf8(text).map_err(|e| PacketBad.context(e))
 }
 
 #[allow(dead_code)]

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -8,8 +8,8 @@ use crate::{
         types::{CommonPlayer, CommonResponse, GenericPlayer},
         GenericResponse,
     },
+    GDError::{PacketBad, UnknownEnumCast},
     GDResult,
-    GDRichError,
 };
 
 use byteorder::ByteOrder;
@@ -175,7 +175,7 @@ impl GameMode {
             "Hardcore" => Ok(GameMode::Hardcore),
             "Spectator" => Ok(GameMode::Spectator),
             "Adventure" => Ok(GameMode::Adventure),
-            _ => Err(GDRichError::unknown_enum_cast_from_into("Unknown gamemode")),
+            _ => Err(UnknownEnumCast.rich(format!("Unknown gamemode {:?}", value))),
         }
     }
 }
@@ -193,7 +193,7 @@ pub(crate) fn get_varint<B: ByteOrder>(buffer: &mut Buffer<B>) -> GDResult<i32> 
 
         // The 5th byte is only allowed to have the 4 smallest bits set
         if i == 4 && (current_byte & 0xf0 != 0) {
-            return Err(GDRichError::packet_bad_from_into("Bad 5th byte"));
+            return Err(PacketBad.rich("Bad 5th byte"));
         }
 
         if (current_byte & msb) == 0 {
@@ -236,7 +236,7 @@ pub(crate) fn get_string<B: ByteOrder>(buffer: &mut Buffer<B>) -> GDResult<Strin
         text.push(buffer.read::<u8>()?)
     }
 
-    String::from_utf8(text).map_err(GDRichError::packet_bad_from_into)
+    String::from_utf8(text).map_err(|e| PacketBad.rich(e))
 }
 
 #[allow(dead_code)]

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -8,7 +8,7 @@ use crate::{
         types::{CommonPlayer, CommonResponse, GenericPlayer},
         GenericResponse,
     },
-    GDError::{PacketBad, UnknownEnumCast},
+    GDErrorKind::{PacketBad, UnknownEnumCast},
     GDResult,
 };
 

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -187,7 +187,6 @@ pub(crate) fn get_varint<B: ByteOrder>(buffer: &mut Buffer<B>) -> GDResult<i32> 
     let mask: u8 = !msb;
 
     for i in 0 .. 5 {
-        println!("Get varint {}", i);
         let current_byte = buffer.read::<u8>()?;
 
         result |= ((current_byte & mask) as i32) << (7 * i);

--- a/src/protocols/quake/client.rs
+++ b/src/protocols/quake/client.rs
@@ -4,7 +4,7 @@ use crate::buffer::{Buffer, Utf8Decoder};
 use crate::protocols::quake::types::Response;
 use crate::protocols::types::TimeoutSettings;
 use crate::socket::{Socket, UdpSocket};
-use crate::{GDError, GDResult};
+use crate::{GDError, GDResult, GDRichError};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::slice::Iter;
@@ -34,7 +34,7 @@ fn get_data<Client: QuakeClient>(address: &SocketAddr, timeout_settings: Option<
     let mut bufferer = Buffer::<LittleEndian>::new(&data);
 
     if bufferer.read::<u32>()? != 4294967295 {
-        return Err(GDError::PacketBad);
+        return Err(GDRichError::packet_bad_from_into("Expected 4294967295"));
     }
 
     let response_header = Client::get_response_header().as_bytes();
@@ -115,7 +115,7 @@ pub(crate) fn client_query<Client: QuakeClient>(
             .or(server_vars.remove("sv_maxclients"))
             .ok_or(GDError::PacketBad)?
             .parse()
-            .map_err(|_| GDError::TypeParse)?,
+            .map_err(GDRichError::type_parse_from_into)?,
         players,
         version: server_vars
             .remove("version")

--- a/src/protocols/quake/client.rs
+++ b/src/protocols/quake/client.rs
@@ -4,8 +4,8 @@ use crate::buffer::{Buffer, Utf8Decoder};
 use crate::protocols::quake::types::Response;
 use crate::protocols::types::TimeoutSettings;
 use crate::socket::{Socket, UdpSocket};
-use crate::GDError::{PacketBad, TypeParse};
-use crate::{GDError, GDResult};
+use crate::GDErrorKind::{PacketBad, TypeParse};
+use crate::{GDErrorKind, GDResult};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::slice::Iter;
@@ -40,7 +40,7 @@ fn get_data<Client: QuakeClient>(address: &SocketAddr, timeout_settings: Option<
 
     let response_header = Client::get_response_header().as_bytes();
     if !bufferer.remaining_bytes().starts_with(response_header) {
-        Err(GDError::PacketBad)?
+        Err(GDErrorKind::PacketBad)?
     }
 
     bufferer.move_cursor(response_header.len() as isize)?;
@@ -105,16 +105,16 @@ pub(crate) fn client_query<Client: QuakeClient>(
         name: server_vars
             .remove("hostname")
             .or(server_vars.remove("sv_hostname"))
-            .ok_or(GDError::PacketBad)?,
+            .ok_or(GDErrorKind::PacketBad)?,
         map: server_vars
             .remove("mapname")
             .or(server_vars.remove("map"))
-            .ok_or(GDError::PacketBad)?,
+            .ok_or(GDErrorKind::PacketBad)?,
         players_online: players.len() as u8,
         players_maximum: server_vars
             .remove("maxclients")
             .or(server_vars.remove("sv_maxclients"))
-            .ok_or(GDError::PacketBad)?
+            .ok_or(GDErrorKind::PacketBad)?
             .parse()
             .map_err(|e| TypeParse.rich(e))?,
         players,

--- a/src/protocols/quake/client.rs
+++ b/src/protocols/quake/client.rs
@@ -4,7 +4,8 @@ use crate::buffer::{Buffer, Utf8Decoder};
 use crate::protocols::quake::types::Response;
 use crate::protocols::types::TimeoutSettings;
 use crate::socket::{Socket, UdpSocket};
-use crate::{GDError, GDResult, GDRichError};
+use crate::GDError::{PacketBad, TypeParse};
+use crate::{GDError, GDResult};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::slice::Iter;
@@ -34,7 +35,7 @@ fn get_data<Client: QuakeClient>(address: &SocketAddr, timeout_settings: Option<
     let mut bufferer = Buffer::<LittleEndian>::new(&data);
 
     if bufferer.read::<u32>()? != 4294967295 {
-        return Err(GDRichError::packet_bad_from_into("Expected 4294967295"));
+        return Err(PacketBad.rich("Expected 4294967295"));
     }
 
     let response_header = Client::get_response_header().as_bytes();
@@ -115,7 +116,7 @@ pub(crate) fn client_query<Client: QuakeClient>(
             .or(server_vars.remove("sv_maxclients"))
             .ok_or(GDError::PacketBad)?
             .parse()
-            .map_err(GDRichError::type_parse_from_into)?,
+            .map_err(|e| TypeParse.rich(e))?,
         players,
         version: server_vars
             .remove("version")

--- a/src/protocols/quake/client.rs
+++ b/src/protocols/quake/client.rs
@@ -35,7 +35,7 @@ fn get_data<Client: QuakeClient>(address: &SocketAddr, timeout_settings: Option<
     let mut bufferer = Buffer::<LittleEndian>::new(&data);
 
     if bufferer.read::<u32>()? != 4294967295 {
-        return Err(PacketBad.rich("Expected 4294967295"));
+        return Err(PacketBad.context("Expected 4294967295"));
     }
 
     let response_header = Client::get_response_header().as_bytes();
@@ -116,7 +116,7 @@ pub(crate) fn client_query<Client: QuakeClient>(
             .or(server_vars.remove("sv_maxclients"))
             .ok_or(GDErrorKind::PacketBad)?
             .parse()
-            .map_err(|e| TypeParse.rich(e))?,
+            .map_err(|e| TypeParse.context(e))?,
         players,
         version: server_vars
             .remove("version")

--- a/src/protocols/quake/one.rs
+++ b/src/protocols/quake/one.rs
@@ -1,7 +1,7 @@
 use crate::protocols::quake::client::{client_query, remove_wrapping_quotes, QuakeClient};
 use crate::protocols::quake::Response;
 use crate::protocols::types::{CommonPlayer, GenericPlayer, TimeoutSettings};
-use crate::{GDError, GDResult};
+use crate::{GDError, GDResult, GDRichError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -47,19 +47,19 @@ impl QuakeClient for QuakeOne {
         Ok(Player {
             id: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             score: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             time: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             ping: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             name: match data.next() {
                 None => Err(GDError::PacketBad)?,
@@ -71,11 +71,11 @@ impl QuakeClient for QuakeOne {
             },
             color_primary: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             color_secondary: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
         })
     }

--- a/src/protocols/quake/one.rs
+++ b/src/protocols/quake/one.rs
@@ -1,8 +1,8 @@
 use crate::protocols::quake::client::{client_query, remove_wrapping_quotes, QuakeClient};
 use crate::protocols::quake::Response;
 use crate::protocols::types::{CommonPlayer, GenericPlayer, TimeoutSettings};
-use crate::GDError::TypeParse;
-use crate::{GDError, GDResult};
+use crate::GDErrorKind::TypeParse;
+use crate::{GDErrorKind, GDResult};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -47,35 +47,35 @@ impl QuakeClient for QuakeOne {
     fn parse_player_string(mut data: Iter<&str>) -> GDResult<Self::Player> {
         Ok(Player {
             id: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             score: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             time: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             ping: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             name: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => remove_wrapping_quotes(v).to_string(),
             },
             skin: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => remove_wrapping_quotes(v).to_string(),
             },
             color_primary: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             color_secondary: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
         })

--- a/src/protocols/quake/one.rs
+++ b/src/protocols/quake/one.rs
@@ -48,19 +48,19 @@ impl QuakeClient for QuakeOne {
         Ok(Player {
             id: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             score: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             time: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             ping: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             name: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
@@ -72,11 +72,11 @@ impl QuakeClient for QuakeOne {
             },
             color_primary: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             color_secondary: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
         })
     }

--- a/src/protocols/quake/one.rs
+++ b/src/protocols/quake/one.rs
@@ -1,7 +1,8 @@
 use crate::protocols::quake::client::{client_query, remove_wrapping_quotes, QuakeClient};
 use crate::protocols::quake::Response;
 use crate::protocols::types::{CommonPlayer, GenericPlayer, TimeoutSettings};
-use crate::{GDError, GDResult, GDRichError};
+use crate::GDError::TypeParse;
+use crate::{GDError, GDResult};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -47,19 +48,19 @@ impl QuakeClient for QuakeOne {
         Ok(Player {
             id: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             score: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             time: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             ping: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             name: match data.next() {
                 None => Err(GDError::PacketBad)?,
@@ -71,11 +72,11 @@ impl QuakeClient for QuakeOne {
             },
             color_primary: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             color_secondary: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
         })
     }

--- a/src/protocols/quake/two.rs
+++ b/src/protocols/quake/two.rs
@@ -2,8 +2,8 @@ use crate::protocols::quake::client::{client_query, remove_wrapping_quotes, Quak
 use crate::protocols::quake::one::QuakeOne;
 use crate::protocols::quake::Response;
 use crate::protocols::types::{CommonPlayer, GenericPlayer, TimeoutSettings};
-use crate::GDError::TypeParse;
-use crate::{GDError, GDResult};
+use crate::GDErrorKind::TypeParse;
+use crate::{GDErrorKind, GDResult};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -46,15 +46,15 @@ impl QuakeClient for QuakeTwo {
     fn parse_player_string(mut data: Iter<&str>) -> GDResult<Self::Player> {
         Ok(Player {
             score: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             ping: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             name: match data.next() {
-                None => Err(GDError::PacketBad)?,
+                None => Err(GDErrorKind::PacketBad)?,
                 Some(v) => remove_wrapping_quotes(v).to_string(),
             },
             address: data.next().map(|v| remove_wrapping_quotes(v).to_string()),

--- a/src/protocols/quake/two.rs
+++ b/src/protocols/quake/two.rs
@@ -2,7 +2,8 @@ use crate::protocols::quake::client::{client_query, remove_wrapping_quotes, Quak
 use crate::protocols::quake::one::QuakeOne;
 use crate::protocols::quake::Response;
 use crate::protocols::types::{CommonPlayer, GenericPlayer, TimeoutSettings};
-use crate::{GDError, GDResult, GDRichError};
+use crate::GDError::TypeParse;
+use crate::{GDError, GDResult};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -46,11 +47,11 @@ impl QuakeClient for QuakeTwo {
         Ok(Player {
             score: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             ping: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
+                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
             },
             name: match data.next() {
                 None => Err(GDError::PacketBad)?,

--- a/src/protocols/quake/two.rs
+++ b/src/protocols/quake/two.rs
@@ -47,11 +47,11 @@ impl QuakeClient for QuakeTwo {
         Ok(Player {
             score: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             ping: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,
-                Some(v) => v.parse().map_err(|e| TypeParse.rich(e))?,
+                Some(v) => v.parse().map_err(|e| TypeParse.context(e))?,
             },
             name: match data.next() {
                 None => Err(GDErrorKind::PacketBad)?,

--- a/src/protocols/quake/two.rs
+++ b/src/protocols/quake/two.rs
@@ -2,7 +2,7 @@ use crate::protocols::quake::client::{client_query, remove_wrapping_quotes, Quak
 use crate::protocols::quake::one::QuakeOne;
 use crate::protocols::quake::Response;
 use crate::protocols::types::{CommonPlayer, GenericPlayer, TimeoutSettings};
-use crate::{GDError, GDResult};
+use crate::{GDError, GDResult, GDRichError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
@@ -46,11 +46,11 @@ impl QuakeClient for QuakeTwo {
         Ok(Player {
             score: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             ping: match data.next() {
                 None => Err(GDError::PacketBad)?,
-                Some(v) => v.parse().map_err(|_| GDError::PacketBad)?,
+                Some(v) => v.parse().map_err(GDRichError::packet_bad_from_into)?,
             },
             name: match data.next() {
                 None => Err(GDError::PacketBad)?,

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -155,13 +155,13 @@ impl TimeoutSettings {
     pub fn new(read: Option<Duration>, write: Option<Duration>) -> GDResult<Self> {
         if let Some(read_duration) = read {
             if read_duration == Duration::new(0, 0) {
-                return Err(InvalidInput.rich("Read duration must not be 0"));
+                return Err(InvalidInput.context("Read duration must not be 0"));
             }
         }
 
         if let Some(write_duration) = write {
             if write_duration == Duration::new(0, 0) {
-                return Err(InvalidInput.rich("Write duration must not be 0"));
+                return Err(InvalidInput.context("Write duration must not be 0"));
             }
         }
 

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -1,5 +1,6 @@
 use crate::protocols::{gamespy, minecraft, quake, valve};
-use crate::{GDError::InvalidInput, GDResult};
+use crate::GDResult;
+use crate::GDRichError;
 
 use std::time::Duration;
 
@@ -149,17 +150,22 @@ pub struct TimeoutSettings {
 
 impl TimeoutSettings {
     /// Construct new settings, passing None will block indefinitely. Passing
-    /// zero Duration throws GDError::[InvalidInput](InvalidInput).
+    /// zero Duration throws
+    /// GDError::[InvalidInput](crate::GDError::InvalidInput).
     pub fn new(read: Option<Duration>, write: Option<Duration>) -> GDResult<Self> {
         if let Some(read_duration) = read {
             if read_duration == Duration::new(0, 0) {
-                return Err(InvalidInput);
+                return Err(GDRichError::invalid_input_from_into(
+                    "Read duration must not be 0",
+                ));
             }
         }
 
         if let Some(write_duration) = write {
             if write_duration == Duration::new(0, 0) {
-                return Err(InvalidInput);
+                return Err(GDRichError::invalid_input_from_into(
+                    "Write duration must not be 0",
+                ));
             }
         }
 
@@ -219,7 +225,7 @@ mod tests {
         // Verify that the function returned an error and that the error type is
         // InvalidInput
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), InvalidInput);
+        assert_eq!(result.unwrap_err(), crate::GDError::InvalidInput.into());
     }
 
     // Test that the default TimeoutSettings values are correct

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -1,6 +1,6 @@
 use crate::protocols::{gamespy, minecraft, quake, valve};
+use crate::GDError::InvalidInput;
 use crate::GDResult;
-use crate::GDRichError;
 
 use std::time::Duration;
 
@@ -155,17 +155,13 @@ impl TimeoutSettings {
     pub fn new(read: Option<Duration>, write: Option<Duration>) -> GDResult<Self> {
         if let Some(read_duration) = read {
             if read_duration == Duration::new(0, 0) {
-                return Err(GDRichError::invalid_input_from_into(
-                    "Read duration must not be 0",
-                ));
+                return Err(InvalidInput.rich("Read duration must not be 0"));
             }
         }
 
         if let Some(write_duration) = write {
             if write_duration == Duration::new(0, 0) {
-                return Err(GDRichError::invalid_input_from_into(
-                    "Write duration must not be 0",
-                ));
+                return Err(InvalidInput.rich("Write duration must not be 0"));
             }
         }
 

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -1,5 +1,5 @@
 use crate::protocols::{gamespy, minecraft, quake, valve};
-use crate::GDError::InvalidInput;
+use crate::GDErrorKind::InvalidInput;
 use crate::GDResult;
 
 use std::time::Duration;
@@ -151,7 +151,7 @@ pub struct TimeoutSettings {
 impl TimeoutSettings {
     /// Construct new settings, passing None will block indefinitely. Passing
     /// zero Duration throws
-    /// GDError::[InvalidInput](crate::GDError::InvalidInput).
+    /// GDErrorKind::[InvalidInput](crate::GDErrorKind::InvalidInput).
     pub fn new(read: Option<Duration>, write: Option<Duration>) -> GDResult<Self> {
         if let Some(read_duration) = read {
             if read_duration == Duration::new(0, 0) {
@@ -221,7 +221,7 @@ mod tests {
         // Verify that the function returned an error and that the error type is
         // InvalidInput
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), crate::GDError::InvalidInput.into());
+        assert_eq!(result.unwrap_err(), crate::GDErrorKind::InvalidInput.into());
     }
 
     // Test that the default TimeoutSettings values are correct

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -97,7 +97,9 @@ impl SplitPacket {
     fn get_payload(&self) -> GDResult<Vec<u8>> {
         if self.compressed {
             let mut decoder = Decoder::new();
-            decoder.write(&self.payload).map_err(|_| Decompress)?;
+            decoder
+                .write(&self.payload)
+                .map_err(|e| Decompress.context(e))?;
 
             let decompressed_size = self.decompressed_size.unwrap() as usize;
 
@@ -105,7 +107,7 @@ impl SplitPacket {
 
             decoder
                 .read(&mut decompressed_payload)
-                .map_err(|_| Decompress)?;
+                .map_err(|e| Decompress.context(e))?;
 
             if decompressed_payload.len() != decompressed_size
                 || crc32fast::hash(&decompressed_payload) != self.uncompressed_crc32.unwrap()

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -448,7 +448,7 @@ fn get_response(
         }
 
         if !is_specified_id {
-            return Err(BadGame(format!("AppId: {}", info.appid)).into());
+            return Err(BadGame.rich(format!("AppId: {}", info.appid)));
         }
     }
 

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -23,7 +23,6 @@ use crate::{
     utils::u8_lower_upper,
     GDError::{BadGame, Decompress, UnknownEnumCast},
     GDResult,
-    GDRichError,
 };
 
 use bzip2_rs::decoder::Decoder;
@@ -111,9 +110,11 @@ impl SplitPacket {
             if decompressed_payload.len() != decompressed_size
                 || crc32fast::hash(&decompressed_payload) != self.uncompressed_crc32.unwrap()
             {
-                Err(GDRichError::decompress_from_into(
-                    "Decompressed size was not expected",
-                ))
+                Err(Decompress.rich(format!(
+                    "Decompressed size {} was not expected {}",
+                    decompressed_payload.len(),
+                    decompressed_size
+                )))
             } else {
                 Ok(decompressed_payload)
             }

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     socket::{Socket, UdpSocket},
     utils::u8_lower_upper,
-    GDError::{BadGame, Decompress, UnknownEnumCast},
+    GDErrorKind::{BadGame, Decompress, UnknownEnumCast},
     GDResult,
 };
 

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -110,7 +110,7 @@ impl SplitPacket {
             if decompressed_payload.len() != decompressed_size
                 || crc32fast::hash(&decompressed_payload) != self.uncompressed_crc32.unwrap()
             {
-                Err(Decompress.rich(format!(
+                Err(Decompress.context(format!(
                     "Decompressed size {} was not expected {}",
                     decompressed_payload.len(),
                     decompressed_size
@@ -448,7 +448,7 @@ fn get_response(
         }
 
         if !is_specified_id {
-            return Err(BadGame.rich(format!("AppId: {}", info.appid)));
+            return Err(BadGame.context(format!("AppId: {}", info.appid)));
         }
     }
 

--- a/src/protocols/valve/protocol.rs
+++ b/src/protocols/valve/protocol.rs
@@ -23,6 +23,7 @@ use crate::{
     utils::u8_lower_upper,
     GDError::{BadGame, Decompress, UnknownEnumCast},
     GDResult,
+    GDRichError,
 };
 
 use bzip2_rs::decoder::Decoder;
@@ -110,7 +111,9 @@ impl SplitPacket {
             if decompressed_payload.len() != decompressed_size
                 || crc32fast::hash(&decompressed_payload) != self.uncompressed_crc32.unwrap()
             {
-                Err(Decompress)
+                Err(GDRichError::decompress_from_into(
+                    "Decompressed size was not expected",
+                ))
             } else {
                 Ok(decompressed_payload)
             }
@@ -444,7 +447,7 @@ fn get_response(
         }
 
         if !is_specified_id {
-            return Err(BadGame(format!("AppId: {}", info.appid)));
+            return Err(BadGame(format!("AppId: {}", info.appid)).into());
         }
     }
 

--- a/src/protocols/valve/types.rs
+++ b/src/protocols/valve/types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::protocols::types::{CommonPlayer, CommonResponse, GenericPlayer};
-use crate::GDError::UnknownEnumCast;
+use crate::GDErrorKind::UnknownEnumCast;
 use crate::GDResult;
 use crate::{buffer::Buffer, protocols::GenericResponse};
 use byteorder::LittleEndian;

--- a/src/services/valve_master_server/service.rs
+++ b/src/services/valve_master_server/service.rs
@@ -72,7 +72,7 @@ impl ValveMasterServer {
         let mut buf = Buffer::<BigEndian>::new(&received_data);
 
         if buf.read::<u32>()? != 4294967295 || buf.read::<u16>()? != 26122 {
-            return Err(PacketBad.rich("Expected 4294967295 or 26122"));
+            return Err(PacketBad.context("Expected 4294967295 or 26122"));
         }
 
         let mut ips: Vec<(IpAddr, u16)> = Vec::new();

--- a/src/services/valve_master_server/service.rs
+++ b/src/services/valve_master_server/service.rs
@@ -2,8 +2,8 @@ use crate::{
     buffer::Buffer,
     socket::{Socket, UdpSocket},
     valve_master_server::{Region, SearchFilters},
-    GDError,
     GDResult,
+    GDRichError,
 };
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -72,7 +72,9 @@ impl ValveMasterServer {
         let mut buf = Buffer::<BigEndian>::new(&received_data);
 
         if buf.read::<u32>()? != 4294967295 || buf.read::<u16>()? != 26122 {
-            return Err(GDError::PacketBad);
+            return Err(GDRichError::packet_bad_from_into(
+                "Expected 4294967295 or 26122",
+            ));
         }
 
         let mut ips: Vec<(IpAddr, u16)> = Vec::new();

--- a/src/services/valve_master_server/service.rs
+++ b/src/services/valve_master_server/service.rs
@@ -2,8 +2,8 @@ use crate::{
     buffer::Buffer,
     socket::{Socket, UdpSocket},
     valve_master_server::{Region, SearchFilters},
+    GDError::PacketBad,
     GDResult,
-    GDRichError,
 };
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -72,9 +72,7 @@ impl ValveMasterServer {
         let mut buf = Buffer::<BigEndian>::new(&received_data);
 
         if buf.read::<u32>()? != 4294967295 || buf.read::<u16>()? != 26122 {
-            return Err(GDRichError::packet_bad_from_into(
-                "Expected 4294967295 or 26122",
-            ));
+            return Err(PacketBad.rich("Expected 4294967295 or 26122"));
         }
 
         let mut ips: Vec<(IpAddr, u16)> = Vec::new();

--- a/src/services/valve_master_server/service.rs
+++ b/src/services/valve_master_server/service.rs
@@ -2,7 +2,7 @@ use crate::{
     buffer::Buffer,
     socket::{Socket, UdpSocket},
     valve_master_server::{Region, SearchFilters},
-    GDError::PacketBad,
+    GDErrorKind::PacketBad,
     GDResult,
 };
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,6 +1,6 @@
 use crate::{
     protocols::types::TimeoutSettings,
-    GDError::{PacketReceive, PacketSend, SocketBind, SocketConnect},
+    GDErrorKind::{PacketReceive, PacketSend, SocketBind, SocketConnect},
     GDResult,
 };
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -29,7 +29,7 @@ pub struct TcpSocket {
 impl Socket for TcpSocket {
     fn new(address: &SocketAddr) -> GDResult<Self> {
         Ok(Self {
-            socket: net::TcpStream::connect(address).map_err(|_| SocketConnect)?,
+            socket: net::TcpStream::connect(address).map_err(|e| SocketConnect.context(e))?,
         })
     }
 
@@ -42,7 +42,7 @@ impl Socket for TcpSocket {
     }
 
     fn send(&mut self, data: &[u8]) -> GDResult<()> {
-        self.socket.write(data).map_err(|_| PacketSend)?;
+        self.socket.write(data).map_err(|e| PacketSend.context(e))?;
         Ok(())
     }
 
@@ -50,7 +50,7 @@ impl Socket for TcpSocket {
         let mut buf = Vec::with_capacity(size.unwrap_or(DEFAULT_PACKET_SIZE));
         self.socket
             .read_to_end(&mut buf)
-            .map_err(|_| PacketReceive)?;
+            .map_err(|e| PacketReceive.context(e))?;
 
         Ok(buf)
     }
@@ -63,7 +63,7 @@ pub struct UdpSocket {
 
 impl Socket for UdpSocket {
     fn new(address: &SocketAddr) -> GDResult<Self> {
-        let socket = net::UdpSocket::bind("0.0.0.0:0").map_err(|_| SocketBind)?;
+        let socket = net::UdpSocket::bind("0.0.0.0:0").map_err(|e| SocketBind.context(e))?;
 
         Ok(Self {
             socket,
@@ -82,14 +82,17 @@ impl Socket for UdpSocket {
     fn send(&mut self, data: &[u8]) -> GDResult<()> {
         self.socket
             .send_to(data, self.address)
-            .map_err(|_| PacketSend)?;
+            .map_err(|e| PacketSend.context(e))?;
 
         Ok(())
     }
 
     fn receive(&mut self, size: Option<usize>) -> GDResult<Vec<u8>> {
         let mut buf: Vec<u8> = vec![0; size.unwrap_or(DEFAULT_PACKET_SIZE)];
-        let (number_of_bytes_received, _) = self.socket.recv_from(&mut buf).map_err(|_| PacketReceive)?;
+        let (number_of_bytes_received, _) = self
+            .socket
+            .recv_from(&mut buf)
+            .map_err(|e| PacketReceive.context(e))?;
 
         Ok(buf[.. number_of_bytes_received].to_vec())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,11 @@
-use crate::{GDResult, GDRichError};
+use crate::GDError::{PacketOverflow, PacketUnderflow};
+use crate::GDResult;
 use std::cmp::Ordering;
 
 pub fn error_by_expected_size(expected: usize, size: usize) -> GDResult<()> {
     match size.cmp(&expected) {
-        Ordering::Greater => Err(GDRichError::packet_underflow(None)),
-        Ordering::Less => Err(GDRichError::packet_underflow(None)),
+        Ordering::Greater => Err(PacketOverflow.into()),
+        Ordering::Less => Err(PacketUnderflow.into()),
         Ordering::Equal => Ok(()),
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,10 @@
-use crate::{
-    GDError::{PacketOverflow, PacketUnderflow},
-    GDResult,
-};
+use crate::{GDResult, GDRichError};
 use std::cmp::Ordering;
 
 pub fn error_by_expected_size(expected: usize, size: usize) -> GDResult<()> {
     match size.cmp(&expected) {
-        Ordering::Greater => Err(PacketOverflow),
-        Ordering::Less => Err(PacketUnderflow),
+        Ordering::Greater => Err(GDRichError::packet_underflow(None)),
+        Ordering::Less => Err(GDRichError::packet_underflow(None)),
         Ordering::Equal => Ok(()),
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::GDError::{PacketOverflow, PacketUnderflow};
+use crate::GDErrorKind::{PacketOverflow, PacketUnderflow};
 use crate::GDResult;
 use std::cmp::Ordering;
 


### PR DESCRIPTION
A first draft of implementing a better error type that propagates source errors and messages.

Requires bumping MSRV to 1.65.0 as it uses [backtraces](https://doc.rust-lang.org/std/backtrace/index.html).

I didn't rename `GDError` as that would require a lot more changes throughout the codebase, however I changed `GDResult` to use the new `GDRichError` (which uses `GDError` as its kind part) and added a From implementation so `GDError`s that are not updated are implicitly converted to the new `GDRichError` (with an added backtrace).

Other than that its a pretty basic type but has a custom debug formatter so an unwrapped error output looks like this:

```
$ RUST_BACKTRACE=1 cargo run --example generic mc-java mc.hypixel.net
Querying 209.222.115.42 with game Game {
    name: "Minecraft (java)",
    default_port: 25565,
    protocol: Minecraft(
        Some(
            Java,
        ),
    ),
}.
Get varint 0
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: PacketUnderflow
"Size requested 1 was larger than remaining bytes 0"
Backtrace [
    { fn: "gamedig::errors::GDRichError::new", file: "./src/errors.rs", line: 102 },
    { fn: "gamedig::errors::GDRichError::packet_underflow", file: "./src/errors.rs", line: 110 },
    { fn: "gamedig::errors::GDRichError::packet_underflow_from_into", file: "./src/errors.rs", line: 121 },
    { fn: "gamedig::buffer::Buffer<B>::read", file: "./src/buffer.rs", line: 110 },
    { fn: "gamedig::protocols::minecraft::types::get_varint", file: "./src/protocols/minecraft/types.rs", line: 191 },
    { fn: "gamedig::protocols::minecraft::protocol::java::Java::receive", file: "./src/protocols/minecraft/protocol/java.rs", line: 53 },
    { fn: "gamedig::protocols::minecraft::protocol::java::Java::get_info", file: "./src/protocols/minecraft/protocol/java.rs", line: 89 },
    { fn: "gamedig::protocols::minecraft::protocol::java::Java::query", file: "./src/protocols/minecraft/protocol/java.rs", line: 148 },
    { fn: "gamedig::protocols::minecraft::protocol::query_java", file: "./src/protocols/minecraft/protocol/mod.rs", line: 46 },
    { fn: "gamedig::games::query_with_timeout", file: "./src/games/mod.rs", line: 162 },
    { fn: "generic::generic_query", file: "./examples/generic.rs", line: 23 },
    { fn: "generic::main", file: "./examples/generic.rs", line: 46 },
    { fn: "core::ops::function::FnOnce::call_once", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/ops/function.rs", line: 250 },
    { fn: "std::sys_common::backtrace::__rust_begin_short_backtrace", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/sys_common/backtrace.rs", line: 135 },
    { fn: "std::rt::lang_start::{{closure}}", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/rt.rs", line: 166 },
    { fn: "core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/ops/function.rs", line: 284 },
    { fn: "std::panicking::try::do_call", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panicking.rs", line: 500 },
    { fn: "std::panicking::try", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panicking.rs", line: 464 },
    { fn: "std::panic::catch_unwind", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panic.rs", line: 142 },
    { fn: "std::rt::lang_start_internal::{{closure}}", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/rt.rs", line: 148 },
    { fn: "std::panicking::try::do_call", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panicking.rs", line: 500 },
    { fn: "std::panicking::try", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panicking.rs", line: 464 },
    { fn: "std::panic::catch_unwind", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panic.rs", line: 142 },
    { fn: "std::rt::lang_start_internal", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/rt.rs", line: 148 },
    { fn: "std::rt::lang_start", file: "/rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/rt.rs", line: 165 },
    { fn: "main" },
    { fn: "__libc_start_main" },
    { fn: "_start" },
]
', examples/generic.rs:46:59
stack backtrace:
   0: rust_begin_unwind
             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/panicking.rs:67:14
   2: core::result::unwrap_failed
             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/result.rs:1651:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/result.rs:1076:23
   4: generic::main
             at ./examples/generic.rs:46:9
   5: core::ops::function::FnOnce::call_once
             at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I need to look into whether implicitly capturing backtraces whenever an error is created (errors are created whenever they are used in or_err etc.) affects performance, although that may be a non-issue as backtraces are only captured if the `RUST_BACKTRACE` environment variable is set.

Related #65 

This error type only allows either an error message or an error source as the error message would be stored as a source by converting `&str` to `Box<dyn std::error::Error + 'static>`.

This doesn't address #65 point 5.