### PR TITLE
[Generic] Add struct for all extra request settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         language: system
         files: '[.]rs$'
         pass_filenames: false
-        entry: cargo test
+        entry: cargo test --bins --lib --examples --all-features
       - id: format
         name: Check rustfmt
         language: system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Crate:
 - Rich errors, capturing backtrace is done on `RUST_BACKTRACE=1`.
 - Applied some nursery Clippy lints.
 
+Generics:
+- Added `ExtraRequestSettings` containing all possible extra request settings.
+- Added `query_with_timeout_and_extra_settings()` to allow generic queries with extra settings.
+
 ### Breaking...
 Crate:
 - The enum used for errors, `GDError` has been renamed to `GDErrorKind`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ Protocols:
 - Minecraft Bedrock
 1. Renamed `version_protocol` to `protocol_version`.
 
+- Minecraft:
+1. Added `request_settings` parameter to `query()`
+
 - The Ship:
 1. Renamed `protocol` to `protocol_version`.
 2. Renamed `max_players` to `players_maximum` and changed its type from `u64` to `u32`.

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -75,7 +75,7 @@ mod test {
     fn test_game(game_name: &str) {
         let timeout_settings =
             Some(TimeoutSettings::new(Some(Duration::from_nanos(1)), Some(Duration::from_nanos(1))).unwrap());
-        assert!(generic_query(game_name, &ADDR, None, timeout_settings).is_err());
+        assert!(generic_query(game_name, &ADDR, None, timeout_settings, None).is_err());
     }
 
     #[test]

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -193,7 +193,14 @@ pub fn query_with_timeout_and_extra_settings(
                 Some(protocols::minecraft::Server::Legacy(group)) => {
                     protocols::minecraft::query_legacy_specific(*group, &socket_addr, timeout_settings).map(Box::new)?
                 }
-                None => protocols::minecraft::query(&socket_addr, timeout_settings).map(Box::new)?,
+                None => {
+                    protocols::minecraft::query(
+                        &socket_addr,
+                        timeout_settings,
+                        extra_settings.map(ExtraRequestSettings::into),
+                    )
+                    .map(Box::new)?
+                }
             }
         }
         Protocol::Gamespy(version) => {

--- a/src/protocols/minecraft/protocol/mod.rs
+++ b/src/protocols/minecraft/protocol/mod.rs
@@ -26,8 +26,12 @@ mod legacy_v1_6;
 
 /// Queries a Minecraft server with all the protocol variants one by one (Java
 /// -> Bedrock -> Legacy (1.6 -> 1.4 -> Beta 1.8)).
-pub fn query(address: &SocketAddr, timeout_settings: Option<TimeoutSettings>) -> GDResult<JavaResponse> {
-    if let Ok(response) = query_java(address, timeout_settings.clone(), None) {
+pub fn query(
+    address: &SocketAddr,
+    timeout_settings: Option<TimeoutSettings>,
+    request_settings: Option<RequestSettings>,
+) -> GDResult<JavaResponse> {
+    if let Ok(response) = query_java(address, timeout_settings.clone(), request_settings) {
         return Ok(response);
     }
 

--- a/src/protocols/minecraft/types.rs
+++ b/src/protocols/minecraft/types.rs
@@ -5,7 +5,7 @@
 use crate::{
     buffer::Buffer,
     protocols::{
-        types::{CommonPlayer, CommonResponse, GenericPlayer},
+        types::{CommonPlayer, CommonResponse, ExtraRequestSettings, GenericPlayer},
         GenericResponse,
     },
     GDErrorKind::{InvalidInput, PacketBad, UnknownEnumCast},
@@ -106,6 +106,16 @@ impl Default for RequestSettings {
         Self {
             hostname: "gamedig".to_string(),
             protocol_version: -1,
+        }
+    }
+}
+
+impl From<ExtraRequestSettings> for RequestSettings {
+    fn from(value: ExtraRequestSettings) -> Self {
+        let default = Self::default();
+        Self {
+            hostname: value.hostname.unwrap_or(default.hostname),
+            protocol_version: value.protocol_version.unwrap_or(default.protocol_version),
         }
     }
 }

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -15,4 +15,4 @@ pub mod types;
 /// Reference: [Server Query](https://developer.valvesoftware.com/wiki/Server_queries)
 pub mod valve;
 
-pub use types::{GenericResponse, Protocol};
+pub use types::{ExtraRequestSettings, GenericResponse, Protocol};

--- a/src/protocols/types.rs
+++ b/src/protocols/types.rs
@@ -185,6 +185,82 @@ impl Default for TimeoutSettings {
     }
 }
 
+/// Generic extra request settings
+///
+/// Fields of this struct may not be used depending on which protocol is
+/// selected, the individual fields link to the specific places they will be
+/// used with additional documentation.
+///
+/// ## Examples
+/// Create minecraft settings with builder:
+/// ```
+/// use gamedig::protocols::{minecraft, ExtraRequestSettings};
+/// let mc_settings: minecraft::RequestSettings = ExtraRequestSettings::default().set_hostname("mc.hypixel.net".to_string()).into();
+/// ```
+///
+/// Create valve settings with builder:
+/// ```
+/// use gamedig::protocols::{valve, ExtraRequestSettings};
+/// let valve_settings: valve::GatheringSettings = ExtraRequestSettings::default().set_check_app_id(false).into();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct ExtraRequestSettings {
+    /// The server's hostname.
+    ///
+    /// Used by:
+    /// - [minecraft::RequestSettings#structfield.hostname]
+    pub hostname: Option<String>,
+    /// The protocol version to use.
+    ///
+    /// Used by:
+    /// - [minecraft::RequestSettings#structfield.protocol_version]
+    pub protocol_version: Option<i32>,
+    /// Whether to gather player information
+    ///
+    /// Used by:
+    /// - [valve::GatheringSettings#structfield.players]
+    pub gather_players: Option<bool>,
+    /// Whether to gather rule information.
+    ///
+    /// Used by:
+    /// - [valve::GatheringSettings#structfield.rules]
+    pub gather_rules: Option<bool>,
+    /// Whether to check if the App ID is valid.
+    ///
+    /// Used by:
+    /// - [valve::GatheringSettings#structfield.check_app_id]
+    pub check_app_id: Option<bool>,
+}
+
+impl ExtraRequestSettings {
+    /// [Sets hostname](ExtraRequestSettings#structfield.hostname)
+    pub fn set_hostname(mut self, hostname: String) -> Self {
+        self.hostname = Some(hostname);
+        self
+    }
+    /// [Sets protocol
+    /// version](ExtraRequestSettings#structfield.protocol_version)
+    pub fn set_protocol_version(mut self, protocol_version: i32) -> Self {
+        self.protocol_version = Some(protocol_version);
+        self
+    }
+    /// [Sets gather players](ExtraRequestSettings#structfield.gather_players)
+    pub fn set_gather_players(mut self, gather_players: bool) -> Self {
+        self.gather_players = Some(gather_players);
+        self
+    }
+    /// [Sets gather rules](ExtraRequestSettings#structfield.gather_rules)
+    pub fn set_gather_rules(mut self, gather_rules: bool) -> Self {
+        self.gather_rules = Some(gather_rules);
+        self
+    }
+    /// [Sets check app ID](ExtraRequestSettings#structfield.check_app_id)
+    pub fn set_check_app_id(mut self, check_app_id: bool) -> Self {
+        self.check_app_id = Some(check_app_id);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +310,14 @@ mod tests {
         // values
         assert_eq!(default_settings.get_read(), Some(Duration::from_secs(4)));
         assert_eq!(default_settings.get_write(), Some(Duration::from_secs(4)));
+    }
+
+    // Test that extra request settings can be converted
+    #[test]
+    fn test_extra_request_settings() {
+        let settings = ExtraRequestSettings::default();
+
+        let _: minecraft::RequestSettings = settings.clone().into();
+        let _: valve::GatheringSettings = settings.into();
     }
 }

--- a/src/protocols/valve/types.rs
+++ b/src/protocols/valve/types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::protocols::types::{CommonPlayer, CommonResponse, GenericPlayer};
+use crate::protocols::types::{CommonPlayer, CommonResponse, ExtraRequestSettings, GenericPlayer};
 use crate::GDErrorKind::UnknownEnumCast;
 use crate::GDResult;
 use crate::{buffer::Buffer, protocols::GenericResponse};
@@ -426,6 +426,17 @@ impl Default for GatheringSettings {
             players: true,
             rules: true,
             check_app_id: true,
+        }
+    }
+}
+
+impl From<ExtraRequestSettings> for GatheringSettings {
+    fn from(value: ExtraRequestSettings) -> Self {
+        let default = Self::default();
+        Self {
+            players: value.gather_players.unwrap_or(default.players),
+            rules: value.gather_rules.unwrap_or(default.rules),
+            check_app_id: value.check_app_id.unwrap_or(default.check_app_id),
         }
     }
 }


### PR DESCRIPTION
Adds a new struct `ExtraRequestSettings` that contains all possible
extra settings for all protocols, and can be implicitly converted with
`.into()` into each protocol's extra settings type.

This is then used in a new query method
`query_with_timeout_and_extra_settings()` that passes the object on to
the selected protocol.

This also updates the generic example to set some of these generic
settings so that it can be used for certain queries like
"mc.hypixel.net".

Closes #86 