### PR TITLE
Retry failed requests

### DIFF
--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -73,8 +73,14 @@ mod test {
     const ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
     fn test_game(game_name: &str) {
-        let timeout_settings =
-            Some(TimeoutSettings::new(Some(Duration::from_nanos(1)), Some(Duration::from_nanos(1))).unwrap());
+        let timeout_settings = Some(
+            TimeoutSettings::new(
+                Some(Duration::from_nanos(1)),
+                Some(Duration::from_nanos(1)),
+                None,
+            )
+            .unwrap(),
+        );
         assert!(generic_query(game_name, &ADDR, None, timeout_settings, None).is_err());
     }
 


### PR DESCRIPTION
I added some logic to retry requests when failed, this seems to make 

```shell
$ cargo run --example generic -- tf2 91.216.250.10
```

fail (less) often for me. (there are still sometimes malformed packet errors but I don't see WouldBlock errors anymore).

The problem with the specific query seems to be that the `players` and `rules` requests sometimes don't receive a response. Inspecting the packet captures the requests look valid so my assumption is that these responses are abnormally large for UDP packets and hence are occasionally dropped on the way to me.

For valve query protocol there might be a better way to solve this as I believe that it supports "paginated" multi-packet responses. But I think that having some retry logic could be useful as internally retrying the individual part of the request that fails might be faster than the caller retrying the entire query.

NOTE: Settings `GatherOptions::{gather_player, gather_rules}` to false avoids my original issue and causes query to succeed every time.