### PR TITLE
[CI] Add node comparison badge

### DIFF
--- a/.github/badges/node.svg
+++ b/.github/badges/node.svg
@@ -1,0 +1,20 @@
+<svg width="156.6" height="20" viewBox="0 0 1566 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Node game coverage: 9%">
+  <title>Node game coverage: 9%</title>
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="m"><rect width="1566" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#m)">
+    <rect width="1276" height="200" fill="#555"/>
+    <rect width="290" height="200" fill="#0f80c1" x="1276"/>
+    <rect width="1566" height="200" fill="url(#a)"/>
+  </g>
+  <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
+    <text x="60" y="148" textLength="1176" fill="#000" opacity="0.25">Node game coverage</text>
+    <text x="50" y="138" textLength="1176">Node game coverage</text>
+    <text x="1331" y="148" textLength="190" fill="#000" opacity="0.25">9%</text>
+    <text x="1321" y="138" textLength="190">9%</text>
+  </g>
+  
+</svg>

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -1,0 +1,70 @@
+# Based on: https://github.com/emibcn/badge-action/blob/master/.github/workflows/test.yml
+name: "Generate node comparison badge"
+
+on:
+  push:
+    paths:
+      - "src/games/definitions.rs"
+      - ".github/workflows/node-badge.yml"
+  schedule:
+    - cron: '0 0 * * 1' # Update once a week in case node-gamedig has changed
+  workflow_dispatch:
+
+jobs:
+  badge:
+    runs-on: "ubuntu-latest"
+    name: Create node comparison badge
+    env:
+      BADGE_PATH: ".github/badges/node.svg"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: "gamedig/node-gamedig"
+          sparse-checkout: "games.txt"
+          path: "node-gamedig"
+
+      - name: Calculate comparison
+        id: comparison
+        run: |
+          # Find list of node games
+          node_games=$(awk -F "|" '/^[^#]/ {if(length($1) > 0) print $1 }' ./node-gamedig/games.txt)
+          node_games_count=$(printf "%s\n" "$node_games" | wc -l)
+
+          # Calculate how many of those games we have definitions for
+          rust_games_count=0
+          for game in $node_games; do
+            if grep "\"$game\" *=>" ./src/games/definitions.rs; then
+              rust_games_count=$(( rust_games_count + 1 ))
+            fi
+          done
+
+          # Calculate percent
+          percent=$(( rust_games_count * 100 / node_games_count))
+
+          echo "$rust_games_count/$node_games_count $percent%"
+          # Output percentage
+          echo "percent=$percent" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate the badge SVG image
+        uses: emibcn/badge-action@v2.0.2
+        id: badge
+        with:
+          label: "Node game coverage"
+          status: "${{ steps.comparison.outputs.percent }}%"
+          color: "0f80c1"
+          path: ${{ env.BADGE_PATH }}
+
+      - name: "Commit badge"
+        continue-on-error: true
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add "${BADGE_PATH}"
+          git commit -m "Add/Update badge"
+
+      - name: Push badge commit
+        uses: ad-m/github-push-action@master
+        if: ${{ success() }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rust-GameDig [![CI](https://github.com/gamedig/rust-gamedig/actions/workflows/ci.yml/badge.svg)](https://github.com/gamedig/rust-gamedig/actions) [![Latest Version](https://img.shields.io/crates/v/gamedig.svg?color=yellow)](https://crates.io/crates/gamedig) [![Crates.io](https://img.shields.io/crates/d/gamedig?color=purple)](https://crates.io/crates/gamedig) [![License:MIT](https://img.shields.io/github/license/gamedig/rust-gamedig?color=blue)](LICENSE.md)
+# rust-GameDig [![CI](https://github.com/gamedig/rust-gamedig/actions/workflows/ci.yml/badge.svg)](https://github.com/gamedig/rust-gamedig/actions) [![Latest Version](https://img.shields.io/crates/v/gamedig.svg?color=yellow)](https://crates.io/crates/gamedig) [![Crates.io](https://img.shields.io/crates/d/gamedig?color=purple)](https://crates.io/crates/gamedig) [![License:MIT](https://img.shields.io/github/license/gamedig/rust-gamedig?color=blue)](LICENSE.md) [![node coverage](./.github/badges/node.svg)](https://github.com/gamedig/node-gamedig)
 
 **Warning**: This project goes through frequent API breaking changes and hasn't been thoroughly tested.
 


### PR DESCRIPTION
Adds a badge to README that shows what percentage of games supported by node-gamedig are supported by us (it doesn't check whether we have a game but use the wrong name for it: it works by checking whether the game ID from node-gamedig exists in are game definitions file). And CI that should automatically update this badge.