### PR TITLE
[CI] Fix misc stuff with labeler CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ ci:
 protocol:
   - src/protocols/**
 
-games:
+game:
   - src/games/**
 
 crate:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,6 @@
 ci:
   - .github/workflows/**
+  - .github/labeler.yml
   - .actrc
   - .pre-commit-config.yaml
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
It's the `game` tag, not `games`.
Adds `labeler.yml` as file for CI tag.
Also uses checkout to avoid `The configuration file (path: .github/labeler.yml) isn't not found locally, fetching via the api` warning.