### PR TITLE
[Protocol] Make gamespy1 parsing less likely to fail

### DIFF
--- a/src/protocols/gamespy/protocols/one/protocol.rs
+++ b/src/protocols/gamespy/protocols/one/protocol.rs
@@ -144,30 +144,19 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
                         .clone()
                 }
             },
-            team: player_data
-                .get("team")
-                .ok_or(GDErrorKind::PacketBad)?
-                .trim()
-                .parse()
-                .map_err(|e| TypeParse.context(e))?,
+            team: match player_data.get("team") {
+                Some(t) => Some(t.trim().parse().map_err(|e| TypeParse.context(e))?),
+                None => None,
+            },
             ping: player_data
                 .get("ping")
                 .ok_or(GDErrorKind::PacketBad)?
                 .trim()
                 .parse()
                 .map_err(|e| TypeParse.context(e))?,
-            face: player_data
-                .get("face")
-                .ok_or(GDErrorKind::PacketBad)?
-                .clone(),
-            skin: player_data
-                .get("skin")
-                .ok_or(GDErrorKind::PacketBad)?
-                .clone(),
-            mesh: player_data
-                .get("mesh")
-                .ok_or(GDErrorKind::PacketBad)?
-                .clone(),
+            face: player_data.get("face").cloned(),
+            skin: player_data.get("skin").cloned(),
+            mesh: player_data.get("mesh").cloned(),
             score: player_data
                 .get("frags")
                 .ok_or(GDErrorKind::PacketBad)?
@@ -182,12 +171,10 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
                 Some(v) => Some(v.trim().parse().map_err(|e| TypeParse.context(e))?),
                 None => None,
             },
-            secret: player_data
-                .get("ngsecret")
-                .ok_or(GDErrorKind::PacketBad)?
-                .to_lowercase()
-                .parse()
-                .map_err(|e| TypeParse.context(e))?,
+            secret: match player_data.get("ngsecret") {
+                Some(s) => Some(s.to_lowercase().parse().map_err(|e| TypeParse.context(e))?),
+                None => None,
+            },
         };
 
         players.push(new_player);

--- a/src/protocols/gamespy/protocols/one/protocol.rs
+++ b/src/protocols/gamespy/protocols/one/protocol.rs
@@ -113,7 +113,8 @@ fn extract_players(server_vars: &mut HashMap<String, String>, players_maximum: u
         };
 
         let early_return = match kind {
-            "team" | "player" | "ping" | "face" | "skin" | "mesh" | "frags" | "ngsecret" | "deaths" | "health" => false,
+            "team" | "player" | "playername" | "ping" | "face" | "skin" | "mesh" | "frags" | "ngsecret" | "deaths"
+            | "health" => false,
             _x => true, // println!("UNKNOWN {id} {x} {value}");
         };
 

--- a/src/protocols/gamespy/protocols/one/types.rs
+++ b/src/protocols/gamespy/protocols/one/types.rs
@@ -12,16 +12,16 @@ use crate::protocols::GenericResponse;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Player {
     pub name: String,
-    pub team: u8,
+    pub team: Option<u8>,
     /// The ping from the server's perspective.
     pub ping: u16,
-    pub face: String,
-    pub skin: String,
-    pub mesh: String,
+    pub face: Option<String>,
+    pub skin: Option<String>,
+    pub mesh: Option<String>,
     pub score: i32,
     pub deaths: Option<u32>,
     pub health: Option<u32>,
-    pub secret: bool,
+    pub secret: Option<bool>,
 }
 
 impl CommonPlayer for Player {


### PR DESCRIPTION
This fixes the "playername" field being filtered out, which would cause parsing to fail for some `bf1942` servers which use that field instead of "player".

It also makes more fields on the Gamespy1 Player type optional, this is because in my testing I saw some servers (`bf1942`) not providing them so as a result the parse would fail if these were not optional.

This is taken from #92 but is just partial work on #88, it might not solve all issues, but they are the obvious fixes that should help us in narrowing down the other ones.