### PR TITLE
Remove `minecraftping` from game definitions as its useless

### DIFF
--- a/src/games/definitions.rs
+++ b/src/games/definitions.rs
@@ -28,7 +28,7 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "minecraft" => game!("Minecraft", 25565, Protocol::Minecraft(None)),
     // Query with specific minecraft protocols
     "minecraftbedrock" => game!("Minecraft (bedrock)", 19132, Protocol::Minecraft(Some(Server::Bedrock))),
-    "minecraftpocket" => game!("Minecraft (bedrock/pocket edition)", 19132, Protocol::Minecraft(Some(Server::Bedrock))),
+    "minecraftpocket" => game!("Minecraft (pocket)", 19132, Protocol::Minecraft(Some(Server::Bedrock))),
     "minecraftjava" => game!("Minecraft (java)", 25565, Protocol::Minecraft(Some(Server::Java))),
     "minecraftlegacy16" => game!("Minecraft (legacy v1.6)", 25565, Protocol::Minecraft(Some(Server::Legacy(LegacyGroup::V1_6)))),
     "minecraftlegacy15" => game!("Minecraft (legacy v1.4-1.5)", 25565, Protocol::Minecraft(Some(Server::Legacy(LegacyGroup::V1_5)))),

--- a/src/games/definitions.rs
+++ b/src/games/definitions.rs
@@ -24,9 +24,8 @@ macro_rules! game {
 
 /// Map of all currently supported games
 pub static GAMES: Map<&'static str, Game> = phf_map! {
-    // Query with all minecraft protocols node-gamedig: minecraft,minecraftping
+    // Query with all minecraft protocols
     "minecraft" => game!("Minecraft", 25565, Protocol::Minecraft(None)),
-    "minecraftping" => game!("Minecraft", 25565, Protocol::Minecraft(None)),
     // Query with specific minecraft protocols
     "minecraftbedrock" => game!("Minecraft (bedrock)", 19132, Protocol::Minecraft(Some(Server::Bedrock))),
     "minecraftpocket" => game!("Minecraft (bedrock/pocket edition)", 19132, Protocol::Minecraft(Some(Server::Bedrock))),


### PR DESCRIPTION
`minecraftping` is the same as `minecraft`, this has been added here to match node-gamedig's id definitions in #100.
There were 2 query methods and the `minecraftping` became the standard `minecraft`, it is being kept there for id backwards compatibility reasons, in [9b92771](https://github.com/gamedig/node-gamedig/commit/9b9277172dc6011bafdc12fe2b99b262129adf28) shows that at some point, this id was marked as "Legacy name".