### PR TITLE
Add Send and Sync on Error Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Who knows what the future holds...
 
 # 0.X.Y - DD/MM/YYYY
 ### Changes:
+Crate:
+- Added `Send` and `Sync` on `Error::source` to fix some async issues.
+
 Protocols:
 - Minecraft Java: Add derives to `RequestSettings` and add `new_just_hostname` that creates new settings just by specifying
 the hostname, `protocol_version` defaults to -1.

--- a/src/errors/error.rs
+++ b/src/errors/error.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fmt::Formatter;
 use std::{backtrace, fmt};
 
-type ErrorSource = Box<dyn Error + 'static>;
+pub(crate) type ErrorSource = Box<dyn Error + Send + Sync>;
 
 /// The GameDig error type.
 ///
@@ -54,7 +54,7 @@ impl PartialEq for GDError {
 }
 
 impl Error for GDError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> { self.source.as_ref().map(Box::as_ref) }
+    fn source(&self) -> Option<&(dyn Error + 'static)> { self.source.as_ref().map(|err| Box::as_ref(err) as _) }
 }
 
 impl fmt::Debug for GDError {
@@ -88,7 +88,7 @@ impl GDError {
     }
 
     /// Create a new error using any type that can be converted to an error
-    pub fn from_error<E: Into<Box<dyn Error + 'static>>>(kind: GDErrorKind, source: E) -> Self {
+    pub fn from_error<E: Into<ErrorSource>>(kind: GDErrorKind, source: E) -> Self {
         Self::new(kind, Some(source.into()))
     }
 }

--- a/src/errors/error.rs
+++ b/src/errors/error.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fmt::Formatter;
 use std::{backtrace, fmt};
 
-pub(crate) type ErrorSource = Box<dyn Error + Send + Sync>;
+pub(crate) type ErrorSource = Box<dyn Error + 'static + Send + Sync>;
 
 /// The GameDig error type.
 ///

--- a/src/errors/kind.rs
+++ b/src/errors/kind.rs
@@ -1,5 +1,5 @@
+use crate::error::ErrorSource;
 use crate::GDError;
-use std::error::Error;
 
 /// All GameDig Error kinds.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,7 +44,7 @@ impl GDErrorKind {
     /// use gamedig::{GDErrorKind, GDResult};
     /// let _: GDResult<u32> = "thing".parse().map_err(|e| GDErrorKind::TypeParse.context(e));
     /// ```
-    pub fn context<E: Into<Box<dyn Error + 'static>>>(self, source: E) -> GDError { GDError::from_error(self, source) }
+    pub fn context<E: Into<ErrorSource>>(self, source: E) -> GDError { GDError::from_error(self, source) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
While working on a personal project, I use juniper subscriptions and I have a stream that inside it calls valve queries.

Before I was on version `0.2.3` and when I tried to upgrade to `0.4.0` I encountered several async problems regarding the error type which came from the stacktracing rework from #80.

This PR adds Send and Sync to the error source type, although I dont know much async rust, I do not know the consequences of doing these (until #37 will come into play at least), thus the request of reviews.