### PR TITLE
Reduce game implementation repetition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Protocols:
 - Minecraft Java: Add derives to `RequestSettings` and add `new_just_hostname` that creates new settings just by specifying
 the hostname, `protocol_version` defaults to -1.
 
+Games:
+- Organised game modules into protocols (when protocol used by other games),
+  you can now access a game by its name or by its protocol name:
+  - `use gamedig::games::teamfortress2;`
+  - `use gamedig::games::valve::teamfortress2;`
+
 Generics:
 - Added standard derives to `ProprietaryProtocol`, `CommonResponseJson`, `CommonPlayerJson`, `TimeoutSettings` and
 `ExtraRequestSettings`.

--- a/src/games/a2oa.rs
+++ b/src/games/a2oa.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(2304)),
-        SteamApp::A2OA.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(A2OA, 2304);

--- a/src/games/a2oa.rs
+++ b/src/games/a2oa.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(A2OA, 2304);

--- a/src/games/alienswarm.rs
+++ b/src/games/alienswarm.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(ALIENSWARM, 27015);

--- a/src/games/alienswarm.rs
+++ b/src/games/alienswarm.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::ALIENSWARM.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(ALIENSWARM, 27015);

--- a/src/games/aoc.rs
+++ b/src/games/aoc.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(AOC, 27015);

--- a/src/games/aoc.rs
+++ b/src/games/aoc.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::AOC.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(AOC, 27015);

--- a/src/games/ase.rs
+++ b/src/games/ase.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::ASE.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(ASE, 27015);

--- a/src/games/ase.rs
+++ b/src/games/ase.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(ASE, 27015);

--- a/src/games/asrd.rs
+++ b/src/games/asrd.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(2304)),
-        SteamApp::ASRD.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(ASRD, 2304);

--- a/src/games/asrd.rs
+++ b/src/games/asrd.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(ASRD, 2304);

--- a/src/games/avorion.rs
+++ b/src/games/avorion.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(AVORION, 27020);

--- a/src/games/avorion.rs
+++ b/src/games/avorion.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27020)),
-        SteamApp::AVORION.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(AVORION, 27020);

--- a/src/games/ballisticoverkill.rs
+++ b/src/games/ballisticoverkill.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27016)),
-        SteamApp::BALLISTICOVERKILL.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(BALLISTICOVERKILL, 27016);

--- a/src/games/ballisticoverkill.rs
+++ b/src/games/ballisticoverkill.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(BALLISTICOVERKILL, 27016);

--- a/src/games/battlefield1942.rs
+++ b/src/games/battlefield1942.rs
@@ -1,8 +1,3 @@
-use crate::protocols::gamespy;
-use crate::protocols::gamespy::one::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::gamespy::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
-    gamespy::one::query(&SocketAddr::new(*address, port.unwrap_or(23000)), None)
-}
+game_query_fn!(one, 23000);

--- a/src/games/battlefield1942.rs
+++ b/src/games/battlefield1942.rs
@@ -1,3 +1,0 @@
-use crate::protocols::gamespy::game_query_fn;
-
-game_query_fn!(one, 23000);

--- a/src/games/blackmesa.rs
+++ b/src/games/blackmesa.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::BLACKMESA.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(BLACKMESA, 27015);

--- a/src/games/blackmesa.rs
+++ b/src/games/blackmesa.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(BLACKMESA, 27015);

--- a/src/games/brainbread2.rs
+++ b/src/games/brainbread2.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(BRAINBREAD2, 27015);

--- a/src/games/brainbread2.rs
+++ b/src/games/brainbread2.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::BRAINBREAD2.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(BRAINBREAD2, 27015);

--- a/src/games/codenamecure.rs
+++ b/src/games/codenamecure.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(CODENAMECURE, 27015);

--- a/src/games/codenamecure.rs
+++ b/src/games/codenamecure.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::CODENAMECURE.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(CODENAMECURE, 27015);

--- a/src/games/colonysurvival.rs
+++ b/src/games/colonysurvival.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(COLONYSURVIVAL, 27004);

--- a/src/games/colonysurvival.rs
+++ b/src/games/colonysurvival.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27004)),
-        SteamApp::COLONYSURVIVAL.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(COLONYSURVIVAL, 27004);

--- a/src/games/counterstrike.rs
+++ b/src/games/counterstrike.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(COUNTERSTRIKE, 27015);

--- a/src/games/counterstrike.rs
+++ b/src/games/counterstrike.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::COUNTERSTRIKE.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(COUNTERSTRIKE, 27015);

--- a/src/games/creativerse.rs
+++ b/src/games/creativerse.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(CREATIVERSE, 26901);

--- a/src/games/creativerse.rs
+++ b/src/games/creativerse.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(26901)),
-        SteamApp::CREATIVERSE.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(CREATIVERSE, 26901);

--- a/src/games/crysiswars.rs
+++ b/src/games/crysiswars.rs
@@ -1,3 +1,0 @@
-use crate::protocols::gamespy::game_query_fn;
-
-game_query_fn!(three, 64100);

--- a/src/games/crysiswars.rs
+++ b/src/games/crysiswars.rs
@@ -1,8 +1,3 @@
-use crate::protocols::gamespy;
-use crate::protocols::gamespy::three::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::gamespy::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
-    gamespy::three::query(&SocketAddr::new(*address, port.unwrap_or(64100)), None)
-}
+game_query_fn!(three, 64100);

--- a/src/games/cscz.rs
+++ b/src/games/cscz.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::CSCZ.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(CSCZ, 27015);

--- a/src/games/cscz.rs
+++ b/src/games/cscz.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(CSCZ, 27015);

--- a/src/games/csgo.rs
+++ b/src/games/csgo.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(CSGO, 27015);

--- a/src/games/csgo.rs
+++ b/src/games/csgo.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::CSGO.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(CSGO, 27015);

--- a/src/games/css.rs
+++ b/src/games/css.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(CSS, 27015);

--- a/src/games/css.rs
+++ b/src/games/css.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::CSS.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(CSS, 27015);

--- a/src/games/definitions.rs
+++ b/src/games/definitions.rs
@@ -89,31 +89,3 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "jc2m" => game!("Just Cause 2: Multiplayer", 7777, Protocol::PROPRIETARY(ProprietaryProtocol::JC2M)),
     "warsow" => game!("Warsow", 44400, Protocol::Quake(QuakeVersion::Three)),
 };
-
-#[cfg(test)]
-mod test {
-    use super::GAMES;
-    use std::fs;
-
-    #[test]
-    fn check_game_files_match_defs() {
-        let ignore = [
-            "mod",         // Module file
-            "definitions", // This file
-            "minecraft",   // Has various defs
-            "sd2d",        // Module names cannot start with numbers
-        ];
-
-        for file in fs::read_dir("./src/games/").unwrap() {
-            let file = file.unwrap();
-            let metadata = file.metadata().unwrap();
-            if metadata.is_file() {
-                if let Some(file_name) = file.file_name().into_string().unwrap().strip_suffix(".rs") {
-                    if !ignore.contains(&file_name) && !GAMES.contains_key(file_name) {
-                        panic!("Expected GAMES to contain a definition to match {file_name}");
-                    }
-                }
-            }
-        }
-    }
-}

--- a/src/games/dod.rs
+++ b/src/games/dod.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::DOD.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(DOD, 27015);

--- a/src/games/dod.rs
+++ b/src/games/dod.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(DOD, 27015);

--- a/src/games/dods.rs
+++ b/src/games/dods.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(DODS, 27015);

--- a/src/games/dods.rs
+++ b/src/games/dods.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::DODS.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(DODS, 27015);

--- a/src/games/doi.rs
+++ b/src/games/doi.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(DOI, 27015);

--- a/src/games/doi.rs
+++ b/src/games/doi.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::DOI.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(DOI, 27015);

--- a/src/games/dst.rs
+++ b/src/games/dst.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(DST, 27016);

--- a/src/games/dst.rs
+++ b/src/games/dst.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27016)),
-        SteamApp::DST.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(DST, 27016);

--- a/src/games/gamespy.rs
+++ b/src/games/gamespy.rs
@@ -4,5 +4,6 @@ use crate::protocols::gamespy::game_query_mod;
 
 game_query_mod!(battlefield1942, "Battlefield 1942", one, 23000);
 game_query_mod!(crysiswars, "Crysis Wars", three, 64100);
+game_query_mod!(hce, "Halo: Combat Evolved", two, 2302);
 game_query_mod!(serioussam, "Serious Sam", one, 25601);
 game_query_mod!(unrealtournament, "Unreal Tournament", one, 7778);

--- a/src/games/gamespy.rs
+++ b/src/games/gamespy.rs
@@ -1,0 +1,8 @@
+//! Gamespy game query modules
+
+use crate::protocols::gamespy::game_query_mod;
+
+game_query_mod!(battlefield1942, "Battlefield 1942", one, 23000);
+game_query_mod!(crysiswars, "Crysis Wars", three, 64100);
+game_query_mod!(serioussam, "Serious Sam", one, 25601);
+game_query_mod!(unrealtournament, "Unreal Tournament", one, 7778);

--- a/src/games/garrysmod.rs
+++ b/src/games/garrysmod.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(GARRYSMOD, 27016);

--- a/src/games/garrysmod.rs
+++ b/src/games/garrysmod.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27016)),
-        SteamApp::GARRYSMOD.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(GARRYSMOD, 27016);

--- a/src/games/hce.rs
+++ b/src/games/hce.rs
@@ -1,8 +1,3 @@
-use crate::protocols::gamespy;
-use crate::protocols::gamespy::two::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::gamespy::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
-    gamespy::two::query(&SocketAddr::new(*address, port.unwrap_or(2302)), None)
-}
+game_query_fn!(two, 2302);

--- a/src/games/hce.rs
+++ b/src/games/hce.rs
@@ -1,3 +1,0 @@
-use crate::protocols::gamespy::game_query_fn;
-
-game_query_fn!(two, 2302);

--- a/src/games/hl2d.rs
+++ b/src/games/hl2d.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(HL2D, 27015);

--- a/src/games/hl2d.rs
+++ b/src/games/hl2d.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::HL2D.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(HL2D, 27015);

--- a/src/games/hlds.rs
+++ b/src/games/hlds.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(HLDS, 27015);

--- a/src/games/hlds.rs
+++ b/src/games/hlds.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::HLDS.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(HLDS, 27015);

--- a/src/games/hll.rs
+++ b/src/games/hll.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(26420)),
-        SteamApp::HLL.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(HLL, 26420);

--- a/src/games/hll.rs
+++ b/src/games/hll.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(HLL, 26420);

--- a/src/games/imic.rs
+++ b/src/games/imic.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::IMIC.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(IMIC, 27015);

--- a/src/games/imic.rs
+++ b/src/games/imic.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(IMIC, 27015);

--- a/src/games/insurgency.rs
+++ b/src/games/insurgency.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(INSURGENCY, 27015);

--- a/src/games/insurgency.rs
+++ b/src/games/insurgency.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::INSURGENCY.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(INSURGENCY, 27015);

--- a/src/games/insurgencysandstorm.rs
+++ b/src/games/insurgencysandstorm.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27131)),
-        SteamApp::INSURGENCYSANDSTORM.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(INSURGENCYSANDSTORM, 27131);

--- a/src/games/insurgencysandstorm.rs
+++ b/src/games/insurgencysandstorm.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(INSURGENCYSANDSTORM, 27131);

--- a/src/games/left4dead.rs
+++ b/src/games/left4dead.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(LEFT4DEAD, 27015);

--- a/src/games/left4dead.rs
+++ b/src/games/left4dead.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::LEFT4DEAD.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(LEFT4DEAD, 27015);

--- a/src/games/left4dead2.rs
+++ b/src/games/left4dead2.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::LEFT4DEAD2.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(LEFT4DEAD2, 27015);

--- a/src/games/left4dead2.rs
+++ b/src/games/left4dead2.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(LEFT4DEAD2, 27015);

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -3,116 +3,36 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// ARMA 2: Operation Arrowhead
-pub mod a2oa;
-/// Alien Swarm
-pub mod alienswarm;
-/// Age of Chivalry
-pub mod aoc;
-/// ARK: Survival Evolved
-pub mod ase;
-/// Alien Swarm: Reactive Drop
-pub mod asrd;
-/// Avorion
-pub mod avorion;
-/// Ballistic Overkill
-pub mod ballisticoverkill;
+pub mod valve;
+
+pub use valve::*;
+
 /// Battalion 1944
 pub mod battalion1944;
 /// Battlefield 1942
 pub mod battlefield1942;
-/// Black Mesa
-pub mod blackmesa;
-/// BrainBread 2
-pub mod brainbread2;
-/// Codename CURE
-pub mod codenamecure;
-/// Colony Survival
-pub mod colonysurvival;
-/// Counter-Strike
-pub mod counterstrike;
-/// Creativerse
-pub mod creativerse;
 /// Crysis Wars
 pub mod crysiswars;
-/// Counter Strike: Condition Zero
-pub mod cscz;
-/// Counter-Strike: Global Offensive
-pub mod csgo;
-/// Counter-Strike: Source
-pub mod css;
-/// Day of Defeat
-pub mod dod;
-/// Day of Defeat: Source
-pub mod dods;
-/// Day of Infamy
-pub mod doi;
-/// Don't Starve Together
-pub mod dst;
 /// Frontlines: Fuel of War
 pub mod ffow;
-/// Garry's Mod
-pub mod garrysmod;
-/// Halo: Combat Evolved
-pub mod hce;
-/// Half-Life 2 Deathmatch
-pub mod hl2d;
-/// Half-Life Deathmatch: Source
-pub mod hlds;
-/// Hell Let Loose
-pub mod hll;
-/// Insurgency: Modern Infantry Combat
-pub mod imic;
-/// Insurgency
-pub mod insurgency;
-/// Insurgency: Sandstorm
-pub mod insurgencysandstorm;
 /// Just Cause 2: Multiplayer
 pub mod jc2m;
-/// Left 4 Dead
-pub mod left4dead;
-/// Left 4 Dead 2
-pub mod left4dead2;
 /// Minecraft
 pub mod minecraft;
-/// Operation: Harsh Doorstop
-pub mod ohd;
-/// Onset
-pub mod onset;
-/// Project Zomboid
-pub mod projectzomboid;
 /// Quake 1
 pub mod quake1;
 /// Quake 2
 pub mod quake2;
 /// Quake 3: Arena
 pub mod quake3;
-/// Risk of Rain 2
-pub mod ror2;
-/// Rust
-pub mod rust;
-/// Sven Co-op
-pub mod sco;
-/// 7 Days To Die
-pub mod sd2d;
 /// Serious Sam
 pub mod serioussam;
 /// Soldier of Fortune 2
 pub mod sof2;
-/// Team Fortress 2
-pub mod teamfortress2;
-/// Team Fortress Classic
-pub mod tfc;
-/// The Forest
-pub mod theforest;
 /// The Ship
 pub mod theship;
 /// Unreal Tournament
 pub mod unrealtournament;
-/// Unturned
-pub mod unturned;
-/// V Rising
-pub mod vrising;
 /// Warsow
 pub mod warsow;
 

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -3,8 +3,10 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub mod quake;
 pub mod valve;
 
+pub use quake::*;
 pub use valve::*;
 
 /// Battalion 1944
@@ -19,22 +21,12 @@ pub mod ffow;
 pub mod jc2m;
 /// Minecraft
 pub mod minecraft;
-/// Quake 1
-pub mod quake1;
-/// Quake 2
-pub mod quake2;
-/// Quake 3: Arena
-pub mod quake3;
 /// Serious Sam
 pub mod serioussam;
-/// Soldier of Fortune 2
-pub mod sof2;
 /// The Ship
 pub mod theship;
 /// Unreal Tournament
 pub mod unrealtournament;
-/// Warsow
-pub mod warsow;
 
 use crate::protocols::gamespy::GameSpyVersion;
 use crate::protocols::quake::QuakeVersion;

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -3,30 +3,24 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub mod gamespy;
 pub mod quake;
 pub mod valve;
 
+pub use gamespy::*;
 pub use quake::*;
 pub use valve::*;
 
 /// Battalion 1944
 pub mod battalion1944;
-/// Battlefield 1942
-pub mod battlefield1942;
-/// Crysis Wars
-pub mod crysiswars;
 /// Frontlines: Fuel of War
 pub mod ffow;
 /// Just Cause 2: Multiplayer
 pub mod jc2m;
 /// Minecraft
 pub mod minecraft;
-/// Serious Sam
-pub mod serioussam;
 /// The Ship
 pub mod theship;
-/// Unreal Tournament
-pub mod unrealtournament;
 
 use crate::protocols::gamespy::GameSpyVersion;
 use crate::protocols::quake::QuakeVersion;

--- a/src/games/ohd.rs
+++ b/src/games/ohd.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(OHD, 27005);

--- a/src/games/ohd.rs
+++ b/src/games/ohd.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27005)),
-        SteamApp::OHD.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(OHD, 27005);

--- a/src/games/onset.rs
+++ b/src/games/onset.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(7776)),
-        SteamApp::ONSET.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(ONSET, 7776);

--- a/src/games/onset.rs
+++ b/src/games/onset.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(ONSET, 7776);

--- a/src/games/projectzomboid.rs
+++ b/src/games/projectzomboid.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(PROJECTZOMBOID, 16261);

--- a/src/games/projectzomboid.rs
+++ b/src/games/projectzomboid.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(16261)),
-        SteamApp::PROJECTZOMBOID.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(PROJECTZOMBOID, 16261);

--- a/src/games/quake.rs
+++ b/src/games/quake.rs
@@ -1,0 +1,9 @@
+//! Quake game query modules
+
+use crate::protocols::quake::game_query_mod;
+
+game_query_mod!(quake1, "Quake 1", one, 27500);
+game_query_mod!(quake2, "Quake 2", two, 27910);
+game_query_mod!(quake3, "Quake 3: Arena", three, 27960);
+game_query_mod!(sof2, "Soldier of Fortune 2", three, 20100);
+game_query_mod!(warsow, "Warsow", three, 44400);

--- a/src/games/quake1.rs
+++ b/src/games/quake1.rs
@@ -1,9 +1,3 @@
-use crate::protocols::quake;
-use crate::protocols::quake::one::Player;
-use crate::protocols::quake::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::quake::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response<Player>> {
-    quake::one::query(&SocketAddr::new(*address, port.unwrap_or(27500)), None)
-}
+game_query_fn!(one, 27500);

--- a/src/games/quake1.rs
+++ b/src/games/quake1.rs
@@ -1,3 +1,0 @@
-use crate::protocols::quake::game_query_fn;
-
-game_query_fn!(one, 27500);

--- a/src/games/quake2.rs
+++ b/src/games/quake2.rs
@@ -1,3 +1,0 @@
-use crate::protocols::quake::game_query_fn;
-
-game_query_fn!(two, 27910);

--- a/src/games/quake2.rs
+++ b/src/games/quake2.rs
@@ -1,9 +1,3 @@
-use crate::protocols::quake;
-use crate::protocols::quake::two::Player;
-use crate::protocols::quake::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::quake::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response<Player>> {
-    quake::two::query(&SocketAddr::new(*address, port.unwrap_or(27910)), None)
-}
+game_query_fn!(two, 27910);

--- a/src/games/quake3.rs
+++ b/src/games/quake3.rs
@@ -1,9 +1,4 @@
-use crate::protocols::quake;
+use crate::protocols::quake::game_query_fn;
 use crate::protocols::quake::two::Player;
-use crate::protocols::quake::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response<Player>> {
-    quake::three::query(&SocketAddr::new(*address, port.unwrap_or(27960)), None)
-}
+game_query_fn!(three, Player, 27960);

--- a/src/games/quake3.rs
+++ b/src/games/quake3.rs
@@ -1,4 +1,0 @@
-use crate::protocols::quake::game_query_fn;
-use crate::protocols::quake::two::Player;
-
-game_query_fn!(three, Player, 27960);

--- a/src/games/ror2.rs
+++ b/src/games/ror2.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27016)),
-        SteamApp::ROR2.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(ROR2, 27016);

--- a/src/games/ror2.rs
+++ b/src/games/ror2.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(ROR2, 27016);

--- a/src/games/rust.rs
+++ b/src/games/rust.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(RUST, 27015);

--- a/src/games/rust.rs
+++ b/src/games/rust.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::RUST.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(RUST, 27015);

--- a/src/games/sco.rs
+++ b/src/games/sco.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(SCO, 27015);

--- a/src/games/sco.rs
+++ b/src/games/sco.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::SCO.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(SCO, 27015);

--- a/src/games/sd2d.rs
+++ b/src/games/sd2d.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(26900)),
-        SteamApp::SD2D.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(SD2D, 26900);

--- a/src/games/sd2d.rs
+++ b/src/games/sd2d.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(SD2D, 26900);

--- a/src/games/serioussam.rs
+++ b/src/games/serioussam.rs
@@ -1,3 +1,0 @@
-use crate::protocols::gamespy::game_query_fn;
-
-game_query_fn!(one, 25601);

--- a/src/games/serioussam.rs
+++ b/src/games/serioussam.rs
@@ -1,8 +1,3 @@
-use crate::protocols::gamespy;
-use crate::protocols::gamespy::one::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::gamespy::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
-    gamespy::one::query(&SocketAddr::new(*address, port.unwrap_or(25601)), None)
-}
+game_query_fn!(one, 25601);

--- a/src/games/sof2.rs
+++ b/src/games/sof2.rs
@@ -1,9 +1,4 @@
-use crate::protocols::quake;
+use crate::protocols::quake::game_query_fn;
 use crate::protocols::quake::two::Player;
-use crate::protocols::quake::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response<Player>> {
-    quake::three::query(&SocketAddr::new(*address, port.unwrap_or(20100)), None)
-}
+game_query_fn!(three, Player, 20100);

--- a/src/games/sof2.rs
+++ b/src/games/sof2.rs
@@ -1,4 +1,0 @@
-use crate::protocols::quake::game_query_fn;
-use crate::protocols::quake::two::Player;
-
-game_query_fn!(three, Player, 20100);

--- a/src/games/teamfortress2.rs
+++ b/src/games/teamfortress2.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(TEAMFORTRESS2, 27015);

--- a/src/games/teamfortress2.rs
+++ b/src/games/teamfortress2.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::TEAMFORTRESS2.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(TEAMFORTRESS2, 27015);

--- a/src/games/tfc.rs
+++ b/src/games/tfc.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::TFC.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(TFC, 27015);

--- a/src/games/tfc.rs
+++ b/src/games/tfc.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(TFC, 27015);

--- a/src/games/theforest.rs
+++ b/src/games/theforest.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(THEFOREST, 27016);

--- a/src/games/theforest.rs
+++ b/src/games/theforest.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27016)),
-        SteamApp::THEFOREST.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(THEFOREST, 27016);

--- a/src/games/unrealtournament.rs
+++ b/src/games/unrealtournament.rs
@@ -1,3 +1,0 @@
-use crate::protocols::gamespy::game_query_fn;
-
-game_query_fn!(one, 7778);

--- a/src/games/unrealtournament.rs
+++ b/src/games/unrealtournament.rs
@@ -1,8 +1,3 @@
-use crate::protocols::gamespy;
-use crate::protocols::gamespy::one::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::gamespy::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
-    gamespy::one::query(&SocketAddr::new(*address, port.unwrap_or(7778)), None)
-}
+game_query_fn!(one, 7778);

--- a/src/games/unturned.rs
+++ b/src/games/unturned.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(UNTURNED, 27015);

--- a/src/games/unturned.rs
+++ b/src/games/unturned.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27015)),
-        SteamApp::UNTURNED.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(UNTURNED, 27015);

--- a/src/games/valve.rs
+++ b/src/games/valve.rs
@@ -1,0 +1,55 @@
+//! Valve game query modules
+
+use crate::protocols::valve::game_query_mod;
+
+game_query_mod!(a2oa, "ARMA 2: Operation Arrowhead", A2OA, 2304);
+game_query_mod!(alienswarm, "Alien Swarm", ALIENSWARM, 27015);
+game_query_mod!(aoc, "Age of Chivalry", AOC, 27015);
+game_query_mod!(ase, "ARK: Survival Evolved", ASE, 27015);
+game_query_mod!(asrd, "Alien Swarm: Reactive Drop", ASRD, 2304);
+game_query_mod!(avorion, "Avorion", AVORION, 27020);
+game_query_mod!(
+    ballisticoverkill,
+    "Ballistic Overkill",
+    BALLISTICOVERKILL,
+    27016
+);
+game_query_mod!(blackmesa, "Black Mesa", BLACKMESA, 27015);
+game_query_mod!(brainbread2, "BrainBread 2", BRAINBREAD2, 27015);
+game_query_mod!(codenamecure, "Codename CURE", CODENAMECURE, 27015);
+game_query_mod!(colonysurvival, "Colony Survival", COLONYSURVIVAL, 27004);
+game_query_mod!(counterstrike, "Counter-Strike", COUNTERSTRIKE, 27015);
+game_query_mod!(creativerse, "Creativerse", CREATIVERSE, 26901);
+game_query_mod!(cscz, "Counter Strike: Condition Zero", CSCZ, 27015);
+game_query_mod!(csgo, "Counter-Strike: Global Offensive", CSGO, 27015);
+game_query_mod!(css, "Counter-Strike: Source", CSS, 27015);
+game_query_mod!(dod, "Day of Defeat", DOD, 27015);
+game_query_mod!(dods, "Day of Defeat: Source", DODS, 27015);
+game_query_mod!(doi, "Day of Infamy", DOI, 27015);
+game_query_mod!(dst, "Don't Starve Together", DST, 27016);
+game_query_mod!(garrysmod, "Garry's Mod", GARRYSMOD, 27016);
+game_query_mod!(hl2d, "Half-Life 2 Deathmatch", HL2D, 27015);
+game_query_mod!(hlds, "Half-Life Deathmatch: Source", HLDS, 27015);
+game_query_mod!(hll, "Hell Let Loose", HLL, 26420);
+game_query_mod!(imic, "Insurgency: Modern Infantry Combat", IMIC, 27015);
+game_query_mod!(insurgency, "Insurgency", INSURGENCY, 27015);
+game_query_mod!(
+    insurgencysandstorm,
+    "Insurgency: Sandstorm",
+    INSURGENCYSANDSTORM,
+    27131
+);
+game_query_mod!(left4dead, "Left 4 Dead", LEFT4DEAD, 27015);
+game_query_mod!(left4dead2, "Left 4 Dead 2", LEFT4DEAD2, 27015);
+game_query_mod!(ohd, "Operation: Harsh Doorstop", OHD, 27005);
+game_query_mod!(onset, "Onset", ONSET, 7776);
+game_query_mod!(projectzomboid, "Project Zomboid", PROJECTZOMBOID, 16261);
+game_query_mod!(ror2, "Risk of Rain 2", ROR2, 27016);
+game_query_mod!(rust, "Rust", RUST, 27015);
+game_query_mod!(sco, "Sven Co-op", SCO, 27015);
+game_query_mod!(sd2d, "7 Days To Die", SD2D, 26900);
+game_query_mod!(teamfortress2, "Team Fortress 2", TEAMFORTRESS2, 27015);
+game_query_mod!(tfc, "Team Fortress Classic", TFC, 27015);
+game_query_mod!(theforest, "The Forest", THEFOREST, 27016);
+game_query_mod!(unturned, "Unturned", UNTURNED, 27015);
+game_query_mod!(vrising, "V Rising", VRISING, 27016);

--- a/src/games/vrising.rs
+++ b/src/games/vrising.rs
@@ -1,3 +1,0 @@
-use crate::protocols::valve::game_query_fn;
-
-game_query_fn!(VRISING, 27016);

--- a/src/games/vrising.rs
+++ b/src/games/vrising.rs
@@ -1,16 +1,3 @@
-use crate::{
-    protocols::valve::{self, game, SteamApp},
-    GDResult,
-};
-use std::net::{IpAddr, SocketAddr};
+use crate::protocols::valve::game_query_fn;
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<game::Response> {
-    let valve_response = valve::query(
-        &SocketAddr::new(*address, port.unwrap_or(27016)),
-        SteamApp::VRISING.as_engine(),
-        None,
-        None,
-    )?;
-
-    Ok(game::Response::new_from_valve_response(valve_response))
-}
+game_query_fn!(VRISING, 27016);

--- a/src/games/warsow.rs
+++ b/src/games/warsow.rs
@@ -1,4 +1,0 @@
-use crate::protocols::quake::game_query_fn;
-use crate::protocols::quake::two::Player;
-
-game_query_fn!(three, Player, 44400);

--- a/src/games/warsow.rs
+++ b/src/games/warsow.rs
@@ -1,9 +1,4 @@
-use crate::protocols::quake;
+use crate::protocols::quake::game_query_fn;
 use crate::protocols::quake::two::Player;
-use crate::protocols::quake::Response;
-use crate::GDResult;
-use std::net::{IpAddr, SocketAddr};
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response<Player>> {
-    quake::three::query(&SocketAddr::new(*address, port.unwrap_or(44400)), None)
-}
+game_query_fn!(three, Player, 44400);

--- a/src/protocols/gamespy/mod.rs
+++ b/src/protocols/gamespy/mod.rs
@@ -32,12 +32,24 @@ pub enum VersionedPlayer<'a> {
     Three(&'a three::Player),
 }
 
+/// Generate a module containing a query function for a gamespy game.
+macro_rules! game_query_mod {
+    ($mod_name: ident, $pretty_name: expr, $gamespy_ver: ident, $default_port: literal) => {
+        #[doc = $pretty_name]
+        pub mod $mod_name {
+            crate::protocols::gamespy::game_query_fn!($gamespy_ver, $default_port);
+        }
+    };
+}
+
+pub(crate) use game_query_mod;
+
 // Allow generating doc comments:
 // https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
 /// Generate a query function for a gamespy game.
 macro_rules! game_query_fn {
     ($gamespy_ver: ident, $default_port: literal) => {
-        game_query_fn! {@gen $gamespy_ver, $default_port, concat!(
+        crate::protocols::gamespy::game_query_fn! {@gen $gamespy_ver, $default_port, concat!(
         "Make a gamespy ", stringify!($gamespy_ver), " query with default timeout settings.\n\n",
         "If port is `None`, then the default port (", stringify!($default_port), ") will be used.")}
     };

--- a/src/protocols/gamespy/mod.rs
+++ b/src/protocols/gamespy/mod.rs
@@ -33,6 +33,12 @@ pub enum VersionedPlayer<'a> {
 }
 
 /// Generate a module containing a query function for a gamespy game.
+///
+/// * `mod_name` - The name to be given to the game module (see ID naming
+///   conventions in CONTRIBUTING.md).
+/// * `pretty_name` - The full name of the game, will be used as the
+///   documentation for the created module.
+/// * `gamespy_ver`, `default_port` - Passed through to [game_query_fn].
 macro_rules! game_query_mod {
     ($mod_name: ident, $pretty_name: expr, $gamespy_ver: ident, $default_port: literal) => {
         #[doc = $pretty_name]
@@ -47,6 +53,15 @@ pub(crate) use game_query_mod;
 // Allow generating doc comments:
 // https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
 /// Generate a query function for a gamespy game.
+///
+/// * `gamespy_ver` - The name of the [module](crate::protocols::gamespy) for
+///   the gamespy version the game uses.
+/// * `default_port` - The default port the game uses.
+///
+/// ```rust,ignore
+/// use crate::protocols::gamespy::game_query_fn;
+/// game_query_fn!(one, 7778);
+/// ```
 macro_rules! game_query_fn {
     ($gamespy_ver: ident, $default_port: literal) => {
         crate::protocols::gamespy::game_query_fn! {@gen $gamespy_ver, $default_port, concat!(

--- a/src/protocols/gamespy/mod.rs
+++ b/src/protocols/gamespy/mod.rs
@@ -31,3 +31,29 @@ pub enum VersionedPlayer<'a> {
     Two(&'a two::Player),
     Three(&'a three::Player),
 }
+
+// Allow generating doc comments:
+// https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
+/// Generate a query function for a gamespy game.
+macro_rules! game_query_fn {
+    ($gamespy_ver: ident, $default_port: literal) => {
+        game_query_fn! {@gen $gamespy_ver, $default_port, concat!(
+        "Make a gamespy ", stringify!($gamespy_ver), " query with default timeout settings.\n\n",
+        "If port is `None`, then the default port (", stringify!($default_port), ") will be used.")}
+    };
+
+    (@gen $gamespy_ver: ident, $default_port: literal, $doc: expr) => {
+        #[doc = $doc]
+        pub fn query(
+            address: &std::net::IpAddr,
+            port: Option<u16>,
+        ) -> crate::GDResult<crate::protocols::gamespy::$gamespy_ver::Response> {
+            crate::protocols::gamespy::$gamespy_ver::query(
+                &std::net::SocketAddr::new(*address, port.unwrap_or($default_port)),
+                None,
+            )
+        }
+    };
+}
+
+pub(crate) use game_query_fn;

--- a/src/protocols/quake/mod.rs
+++ b/src/protocols/quake/mod.rs
@@ -19,17 +19,25 @@ pub enum QuakeVersion {
     Three,
 }
 
+/// Generate a module containing a query function for a quake game.
+macro_rules! game_query_mod {
+    ($mod_name: ident, $pretty_name: expr, $quake_ver: ident, $default_port: literal) => {
+        #[doc = $pretty_name]
+        pub mod $mod_name {
+            crate::protocols::quake::game_query_fn!($quake_ver, $default_port);
+        }
+    };
+}
+
+pub(crate) use game_query_mod;
+
 // Allow generating doc comments:
 // https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
 /// Generate a query function for a quake game.
 macro_rules! game_query_fn {
     ($quake_ver: ident, $default_port: literal) => {
         use crate::protocols::quake::$quake_ver::Player;
-        game_query_fn! {$quake_ver, Player, $default_port}
-    };
-
-    ($quake_ver: ident, $player_type: ty, $default_port: literal) => {
-        game_query_fn! {@gen $quake_ver, $player_type, $default_port, concat!(
+        crate::protocols::quake::game_query_fn! {@gen $quake_ver, Player, $default_port, concat!(
         "Make a quake ", stringify!($quake_ver), " query with default timeout settings.\n\n",
         "If port is `None`, then the default port (", stringify!($default_port), ") will be used.")}
     };

--- a/src/protocols/quake/mod.rs
+++ b/src/protocols/quake/mod.rs
@@ -20,6 +20,12 @@ pub enum QuakeVersion {
 }
 
 /// Generate a module containing a query function for a quake game.
+///
+/// * `mod_name` - The name to be given to the game module (see ID naming
+///   conventions in CONTRIBUTING.md).
+/// * `pretty_name` - The full name of the game, will be used as the
+///   documentation for the created module.
+/// * `quake_ver`, `default_port` - Passed through to [game_query_fn].
 macro_rules! game_query_mod {
     ($mod_name: ident, $pretty_name: expr, $quake_ver: ident, $default_port: literal) => {
         #[doc = $pretty_name]
@@ -34,6 +40,15 @@ pub(crate) use game_query_mod;
 // Allow generating doc comments:
 // https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
 /// Generate a query function for a quake game.
+///
+/// * `quake_ver` - The name of the [module](crate::protocols::quake) for the
+///   quake version the game uses.
+/// * `default_port` - The default port the game uses.
+///
+/// ```rust,ignore
+/// use crate::protocols::quake::game_query_fn;
+/// game_query_fn!(one, 27500);
+/// ```
 macro_rules! game_query_fn {
     ($quake_ver: ident, $default_port: literal) => {
         use crate::protocols::quake::$quake_ver::Player;

--- a/src/protocols/quake/three.rs
+++ b/src/protocols/quake/three.rs
@@ -1,10 +1,12 @@
 use crate::protocols::quake::client::{client_query, QuakeClient};
-use crate::protocols::quake::two::{Player, QuakeTwo};
+use crate::protocols::quake::two::QuakeTwo;
 use crate::protocols::quake::Response;
 use crate::protocols::types::TimeoutSettings;
 use crate::GDResult;
 use std::net::SocketAddr;
 use std::slice::Iter;
+
+pub use crate::protocols::quake::two::Player;
 
 struct QuakeThree;
 impl QuakeClient for QuakeThree {

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -6,12 +6,23 @@ pub mod types;
 pub use protocol::*;
 pub use types::*;
 
+macro_rules! game_query_mod {
+    ($mod_name: ident, $pretty_name: expr, $steam_app: ident, $default_port: literal) => {
+        #[doc = $pretty_name]
+        pub mod $mod_name {
+            crate::protocols::valve::game_query_fn!($steam_app, $default_port);
+        }
+    };
+}
+
+pub(crate) use game_query_mod;
+
 // Allow generating doc comments:
 // https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
 /// Generate a query function for a valve game.
 macro_rules! game_query_fn {
     ($steam_app: ident, $default_port: literal) => {
-        game_query_fn!{@gen $steam_app, $default_port, concat!(
+        crate::protocols::valve::game_query_fn!{@gen $steam_app, $default_port, concat!(
             "Make a valve query for ", stringify!($steam_app), " with default timeout settings and default extra request settings.\n\n",
             "If port is `None`, then the default port (", stringify!($default_port), ") will be used.")}
     };

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -5,3 +5,30 @@ pub mod types;
 
 pub use protocol::*;
 pub use types::*;
+
+// Allow generating doc comments:
+// https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
+/// Generate a query function for a valve game.
+macro_rules! game_query_fn {
+    ($steam_app: ident, $default_port: literal) => {
+        game_query_fn!{@gen $steam_app, $default_port, concat!(
+            "Make a valve query for ", stringify!($steam_app), " with default timeout settings and default extra request settings.\n\n",
+            "If port is `None`, then the default port (", stringify!($default_port), ") will be used.")}
+    };
+
+    (@gen $steam_app: ident, $default_port: literal, $doc: expr) => {
+        #[doc = $doc]
+        pub fn query(address: &std::net::IpAddr, port: Option<u16>) -> crate::GDResult<crate::protocols::valve::game::Response> {
+            let valve_response = crate::protocols::valve::query(
+                &std::net::SocketAddr::new(*address, port.unwrap_or($default_port)),
+                crate::protocols::valve::SteamApp::$steam_app.as_engine(),
+                None,
+                None,
+            )?;
+
+            Ok(crate::protocols::valve::game::Response::new_from_valve_response(valve_response))
+        }
+    };
+}
+
+pub(crate) use game_query_fn;

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -6,6 +6,13 @@ pub mod types;
 pub use protocol::*;
 pub use types::*;
 
+/// Generate a module containing a query function for a valve game.
+///
+/// * `mod_name` - The name to be given to the game module (see ID naming
+///   conventions in CONTRIBUTING.md).
+/// * `pretty_name` - The full name of the game, will be used as the
+///   documentation for the created module.
+/// * `steam_app`, `default_port` - Passed through to [game_query_fn].
 macro_rules! game_query_mod {
     ($mod_name: ident, $pretty_name: expr, $steam_app: ident, $default_port: literal) => {
         #[doc = $pretty_name]
@@ -20,6 +27,14 @@ pub(crate) use game_query_mod;
 // Allow generating doc comments:
 // https://users.rust-lang.org/t/macros-filling-text-in-comments/20473
 /// Generate a query function for a valve game.
+///
+/// * `steam_app` - The entry in the [SteamApp] enum that the game uses.
+/// * `default_port` - The default port the game uses.
+///
+/// ```rust,ignore
+/// use crate::protocols::valve::game_query_fn;
+/// game_query_fn!(TEAMFORTRESS2, 27015);
+/// ```
 macro_rules! game_query_fn {
     ($steam_app: ident, $default_port: literal) => {
         crate::protocols::valve::game_query_fn!{@gen $steam_app, $default_port, concat!(


### PR DESCRIPTION
Using macros we can reduce the amount of code we have to write for each game.

Further reduction is likely possible if we wrote a macro that made use of the generic implementation and called the game query function macro generation as well as the game definition generation macro from the same place. But I think a ~500 line reduction is a good start.

These macros have the added nicety of generating doc comments for all the game query function based on the protocol, game name/protocol version, and default port.

Closes #120.