### PR TITLE
feat: Add GatheringSettings on Valve macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Who knows what the future holds...
 
 # 0.X.Y - DD/MM/YYYY
 ### Changes:
-Nothing yet.
+- Added [Valheim](https://store.steampowered.com/app/892970/Valheim/) support.
 
 ### Breaking:
 None, yaay!

--- a/GAMES.md
+++ b/GAMES.md
@@ -62,6 +62,7 @@ Beware of the `Notes` column, as it contains information about query port offset
 | Creativerse                        | CREATIVERSE         | Valve                | Query Port offset: 1.                                                                                                                                                     |
 | Garry's Mod                        | GARRYSMOD           | Valve                |                                                                                                                                                                           |
 | Barotrauma                         | BAROTRAUMA          | Valve                | Query Port offset: 1.                                                                                                                                                     |
+| Valheim                            | VALHEIM             | Valve                | Query Port offset: 1. Does not respond to the A2S rules.                                                                                                                  |
 
 ## Planned to add support:
 _

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -27,20 +27,6 @@ fn generic_query(
     Ok(response)
 }
 
-fn generic_query_by_name(
-    game_name: &str,
-    addr: &IpAddr,
-    port: Option<u16>,
-    timeout_settings: Option<TimeoutSettings>,
-    extra_settings: Option<ExtraRequestSettings>,
-) -> GDResult<Box<dyn CommonResponse>> {
-    let game = GAMES
-        .get(&game_name)
-        .expect("Game doesn't exist, run without arguments to see a list of games");
-
-    generic_query(game, addr, port, timeout_settings, extra_settings)
-}
-
 fn main() {
     let mut args = std::env::args().skip(1);
 
@@ -109,7 +95,12 @@ mod test {
             )
             .unwrap(),
         );
-        assert!(generic_query_by_name(game_name, &ADDR, None, timeout_settings, None).is_err());
+
+        let game = GAMES
+            .get(game_name)
+            .expect("Game doesn't exist, run without arguments to see a list of games");
+
+        assert!(generic_query(game, &ADDR, None, timeout_settings, None).is_err());
     }
 
     #[test]

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -9,6 +9,7 @@ use gamedig::{
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 
 /// Make a query given the name of a game
+/// The `game` argument is taken from the [GAMES](gamedig::GAMES) map.
 fn generic_query(
     game: &Game,
     addr: &IpAddr,
@@ -82,7 +83,7 @@ mod test {
         time::Duration,
     };
 
-    use super::{generic_query, generic_query_by_name};
+    use super::generic_query;
 
     const ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 

--- a/src/games/definitions.rs
+++ b/src/games/definitions.rs
@@ -86,6 +86,7 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "theship" => game!("The Ship", 27015, Protocol::PROPRIETARY(ProprietaryProtocol::TheShip)),
     "unturned" => game!("Unturned", 27015, Protocol::Valve(SteamApp::UNTURNED)),
     "unrealtournament" => game!("Unreal Tournament", 7778, Protocol::Gamespy(GameSpyVersion::One)),
+    "valheim" => game!("Valheim", 2457, Protocol::Valve(SteamApp::VALHEIM)),
     "vrising" => game!("V Rising", 27016, Protocol::Valve(SteamApp::VRISING)),
     "jc2m" => game!("Just Cause 2: Multiplayer", 7777, Protocol::PROPRIETARY(ProprietaryProtocol::JC2M)),
     "warsow" => game!("Warsow", 44400, Protocol::Quake(QuakeVersion::Three)),

--- a/src/games/definitions.rs
+++ b/src/games/definitions.rs
@@ -10,14 +10,25 @@ use crate::protocols::{
 use crate::Game;
 
 use crate::protocols::types::ProprietaryProtocol;
+use crate::protocols::valve::GatheringSettings;
 use phf::{phf_map, Map};
 
 macro_rules! game {
     ($name: literal, $default_port: literal, $protocol: expr) => {
+        game!(
+            $name,
+            $default_port,
+            $protocol,
+            GatheringSettings::default().into_extra()
+        )
+    };
+
+    ($name: literal, $default_port: literal, $protocol: expr, $extra_request_settings: expr) => {
         Game {
             name: $name,
             default_port: $default_port,
             protocol: $protocol,
+            request_settings: $extra_request_settings,
         }
     };
 }
@@ -86,7 +97,11 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "theship" => game!("The Ship", 27015, Protocol::PROPRIETARY(ProprietaryProtocol::TheShip)),
     "unturned" => game!("Unturned", 27015, Protocol::Valve(SteamApp::UNTURNED)),
     "unrealtournament" => game!("Unreal Tournament", 7778, Protocol::Gamespy(GameSpyVersion::One)),
-    "valheim" => game!("Valheim", 2457, Protocol::Valve(SteamApp::VALHEIM)),
+    "valheim" => game!("Valheim", 2457, Protocol::Valve(SteamApp::VALHEIM), GatheringSettings {
+        players: true,
+        rules: false,
+        check_app_id: true,
+    }.into_extra()),
     "vrising" => game!("V Rising", 27016, Protocol::Valve(SteamApp::VRISING)),
     "jc2m" => game!("Just Cause 2: Multiplayer", 7777, Protocol::PROPRIETARY(ProprietaryProtocol::JC2M)),
     "warsow" => game!("Warsow", 44400, Protocol::Quake(QuakeVersion::Three)),

--- a/src/games/mod.rs
+++ b/src/games/mod.rs
@@ -39,6 +39,8 @@ pub struct Game {
     pub default_port: u16,
     /// The protocol the game's query uses
     pub protocol: Protocol,
+    /// Request settings.
+    pub request_settings: ExtraRequestSettings,
 }
 
 #[cfg(feature = "game_defs")]
@@ -78,7 +80,9 @@ pub fn query_with_timeout_and_extra_settings(
             protocols::valve::query(
                 &socket_addr,
                 steam_app.as_engine(),
-                extra_settings.map(ExtraRequestSettings::into),
+                extra_settings
+                    .or(Option::from(game.request_settings.clone()))
+                    .map(ExtraRequestSettings::into),
                 timeout_settings,
             )
             .map(Box::new)?

--- a/src/games/valve.rs
+++ b/src/games/valve.rs
@@ -1,6 +1,7 @@
 //! Valve game query modules
 
 use crate::protocols::valve::game_query_mod;
+use crate::protocols::valve::types::GatheringSettings;
 
 game_query_mod!(a2oa, "ARMA 2: Operation Arrowhead", A2OA, 2304);
 game_query_mod!(alienswarm, "Alien Swarm", ALIENSWARM, 27015);
@@ -53,4 +54,15 @@ game_query_mod!(teamfortress2, "Team Fortress 2", TEAMFORTRESS2, 27015);
 game_query_mod!(tfc, "Team Fortress Classic", TFC, 27015);
 game_query_mod!(theforest, "The Forest", THEFOREST, 27016);
 game_query_mod!(unturned, "Unturned", UNTURNED, 27015);
+game_query_mod!(
+    valheim,
+    "Valheim",
+    VALHEIM,
+    2457,
+    GatheringSettings {
+        players: true,
+        rules: false,
+        check_app_id: true,
+    }
+);
 game_query_mod!(vrising, "V Rising", VRISING, 27016);

--- a/src/games/valve.rs
+++ b/src/games/valve.rs
@@ -1,7 +1,6 @@
 //! Valve game query modules
 
 use crate::protocols::valve::game_query_mod;
-use crate::protocols::valve::types::GatheringSettings;
 
 game_query_mod!(a2oa, "ARMA 2: Operation Arrowhead", A2OA, 2304);
 game_query_mod!(alienswarm, "Alien Swarm", ALIENSWARM, 27015);

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -6,8 +6,6 @@ pub mod types;
 pub use protocol::*;
 pub use types::*;
 
-use crate::protocols::valve::types::GatheringSettings;
-
 /// Generate a module containing a query function for a valve game.
 ///
 /// * `mod_name` - The name to be given to the game module (see ID naming
@@ -22,13 +20,15 @@ macro_rules! game_query_mod {
             $pretty_name,
             $steam_app,
             $default_port,
-            crate::protocols::valve::types::GatheringSettings::default()
+            GatheringSettings::default()
         );
     };
 
     ($mod_name: ident, $pretty_name: expr, $steam_app: ident, $default_port: literal, $gathering_settings: expr) => {
         #[doc = $pretty_name]
         pub mod $mod_name {
+            use crate::protocols::valve::GatheringSettings;
+
             crate::protocols::valve::game_query_fn!($steam_app, $default_port, $gathering_settings);
         }
     };
@@ -60,8 +60,8 @@ macro_rules! game_query_fn {
             let valve_response = crate::protocols::valve::query(
                 &std::net::SocketAddr::new(*address, port.unwrap_or($default_port)),
                 crate::protocols::valve::SteamApp::$steam_app.as_engine(),
-                None,
                 Some($gathering_settings),
+                None,
             )?;
 
             Ok(crate::protocols::valve::game::Response::new_from_valve_response(valve_response))

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -49,6 +49,7 @@ pub(crate) use game_query_mod;
 /// ```
 macro_rules! game_query_fn {
     ($steam_app: ident, $default_port: literal, $gathering_settings: expr) => {
+        // TODO: By using $gathering_settings, also add to doc if a game doesnt respond to certain gathering settings
         crate::protocols::valve::game_query_fn!{@gen $steam_app, $default_port, concat!(
             "Make a valve query for ", stringify!($steam_app), " with default timeout settings and default extra request settings.\n\n",
             "If port is `None`, then the default port (", stringify!($default_port), ") will be used."), $gathering_settings}

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -39,17 +39,17 @@ macro_rules! game_query_fn {
     ($steam_app: ident, $default_port: literal) => {
         crate::protocols::valve::game_query_fn!{@gen $steam_app, $default_port, concat!(
             "Make a valve query for ", stringify!($steam_app), " with default timeout settings and default extra request settings.\n\n",
-            "If port is `None`, then the default port (", stringify!($default_port), ") will be used.")}
+            "If port is `None`, then the default port (", stringify!($default_port), ") will be used."), None}
     };
 
-    (@gen $steam_app: ident, $default_port: literal, $doc: expr) => {
+    (@gen $steam_app: ident, $default_port: literal, $doc: expr, $gathering_settings: expr) => {
         #[doc = $doc]
         pub fn query(address: &std::net::IpAddr, port: Option<u16>) -> crate::GDResult<crate::protocols::valve::game::Response> {
             let valve_response = crate::protocols::valve::query(
                 &std::net::SocketAddr::new(*address, port.unwrap_or($default_port)),
                 crate::protocols::valve::SteamApp::$steam_app.as_engine(),
                 None,
-                None,
+                $gathering_settings,
             )?;
 
             Ok(crate::protocols::valve::game::Response::new_from_valve_response(valve_response))

--- a/src/protocols/valve/types.rs
+++ b/src/protocols/valve/types.rs
@@ -341,6 +341,8 @@ pub enum SteamApp {
     HLL,
     /// Barotrauma
     BAROTRAUMA,
+    /// Valheim
+    VALHEIM,
 }
 
 impl SteamApp {
@@ -383,6 +385,7 @@ impl SteamApp {
             Self::BAROTRAUMA => Engine::new_source(602960),
             Self::ROR2 => Engine::new_source(632_360),
             Self::OHD => Engine::new_source_with_dedicated(736_590, 950_900),
+            Self::VALHEIM => Engine::new_source(892_970),
             Self::ONSET => Engine::new_source(1_105_810),
             Self::VRISING => Engine::new_source(1_604_030),
             Self::HLL => Engine::new_source(686_810),

--- a/src/protocols/valve/types.rs
+++ b/src/protocols/valve/types.rs
@@ -425,15 +425,29 @@ pub struct GatheringSettings {
     pub check_app_id: bool,
 }
 
-impl Default for GatheringSettings {
+impl GatheringSettings {
     /// Default values are true for both the players and the rules.
-    fn default() -> Self {
+    pub const fn default() -> Self {
         Self {
             players: true,
             rules: true,
             check_app_id: true,
         }
     }
+
+    pub const fn into_extra(self) -> ExtraRequestSettings {
+        ExtraRequestSettings {
+            hostname: None,
+            protocol_version: None,
+            gather_players: Some(self.players),
+            gather_rules: Some(self.rules),
+            check_app_id: Some(self.check_app_id),
+        }
+    }
+}
+
+impl Default for GatheringSettings {
+    fn default() -> Self { GatheringSettings::default() }
 }
 
 impl From<ExtraRequestSettings> for GatheringSettings {


### PR DESCRIPTION
This PR aims to add an optional additional parameter on the `game_query_mod` and `game` macros regarding specifying `GatheringSettings` as some games don't respond to certain A2S queries (I have also added support for Valheim to show this (it does not respond to rules but does on players)).

Still need to be done to merge this:
- [x] ~~On game_query_mod modify the docs to mention if a game will not query for players/rules as it wont respond.~~ see comments
- [x] Modify the `game!` macro for generics to also support this.