### PR TITLE
protocols: Only compile game impl macros when they are needed

### DIFF
--- a/src/protocols/gamespy/mod.rs
+++ b/src/protocols/gamespy/mod.rs
@@ -39,6 +39,7 @@ pub enum VersionedPlayer<'a> {
 /// * `pretty_name` - The full name of the game, will be used as the
 ///   documentation for the created module.
 /// * `gamespy_ver`, `default_port` - Passed through to [game_query_fn].
+#[cfg(feature = "games")]
 macro_rules! game_query_mod {
     ($mod_name: ident, $pretty_name: expr, $gamespy_ver: ident, $default_port: literal) => {
         #[doc = $pretty_name]
@@ -48,6 +49,7 @@ macro_rules! game_query_mod {
     };
 }
 
+#[cfg(feature = "games")]
 pub(crate) use game_query_mod;
 
 // Allow generating doc comments:
@@ -62,6 +64,7 @@ pub(crate) use game_query_mod;
 /// use crate::protocols::gamespy::game_query_fn;
 /// game_query_fn!(one, 7778);
 /// ```
+#[cfg(feature = "games")]
 macro_rules! game_query_fn {
     ($gamespy_ver: ident, $default_port: literal) => {
         crate::protocols::gamespy::game_query_fn! {@gen $gamespy_ver, $default_port, concat!(
@@ -83,4 +86,5 @@ macro_rules! game_query_fn {
     };
 }
 
+#[cfg(feature = "games")]
 pub(crate) use game_query_fn;

--- a/src/protocols/quake/mod.rs
+++ b/src/protocols/quake/mod.rs
@@ -26,6 +26,7 @@ pub enum QuakeVersion {
 /// * `pretty_name` - The full name of the game, will be used as the
 ///   documentation for the created module.
 /// * `quake_ver`, `default_port` - Passed through to [game_query_fn].
+#[cfg(feature = "games")]
 macro_rules! game_query_mod {
     ($mod_name: ident, $pretty_name: expr, $quake_ver: ident, $default_port: literal) => {
         #[doc = $pretty_name]
@@ -35,6 +36,7 @@ macro_rules! game_query_mod {
     };
 }
 
+#[cfg(feature = "games")]
 pub(crate) use game_query_mod;
 
 // Allow generating doc comments:
@@ -49,6 +51,7 @@ pub(crate) use game_query_mod;
 /// use crate::protocols::quake::game_query_fn;
 /// game_query_fn!(one, 27500);
 /// ```
+#[cfg(feature = "games")]
 macro_rules! game_query_fn {
     ($quake_ver: ident, $default_port: literal) => {
         use crate::protocols::quake::$quake_ver::Player;
@@ -71,4 +74,5 @@ macro_rules! game_query_fn {
     };
 }
 
+#[cfg(feature = "games")]
 pub(crate) use game_query_fn;

--- a/src/protocols/valve/mod.rs
+++ b/src/protocols/valve/mod.rs
@@ -13,6 +13,7 @@ pub use types::*;
 /// * `pretty_name` - The full name of the game, will be used as the
 ///   documentation for the created module.
 /// * `steam_app`, `default_port` - Passed through to [game_query_fn].
+#[cfg(feature = "games")]
 macro_rules! game_query_mod {
     ($mod_name: ident, $pretty_name: expr, $engine: expr, $default_port: literal) => {
         crate::protocols::valve::game_query_mod!(
@@ -34,6 +35,7 @@ macro_rules! game_query_mod {
     };
 }
 
+#[cfg(feature = "games")]
 pub(crate) use game_query_mod;
 
 // Allow generating doc comments:
@@ -47,6 +49,7 @@ pub(crate) use game_query_mod;
 /// use crate::protocols::valve::game_query_fn;
 /// game_query_fn!(TEAMFORTRESS2, 27015);
 /// ```
+#[cfg(feature = "games")]
 macro_rules! game_query_fn {
     ($pretty_name: expr, $engine: expr, $default_port: literal, $gathering_settings: expr) => {
         // TODO: By using $gathering_settings, also add to doc if a game doesnt respond to certain gathering settings
@@ -70,4 +73,5 @@ macro_rules! game_query_fn {
     };
 }
 
+#[cfg(feature = "games")]
 pub(crate) use game_query_fn;


### PR DESCRIPTION
These macros are only required when compiling the code gated behind the games feature, they are unused if that feature is not and are also crate only.