### PR TITLE
ci: Update node coverage badge to work without games.txt

### DIFF
--- a/.github/badges/node.svg
+++ b/.github/badges/node.svg
@@ -1,20 +1,20 @@
-<svg width="163.6" height="20" viewBox="0 0 1636 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Node game coverage: 13%">
-  <title>Node game coverage: 13%</title>
+<svg width="181.6" height="20" viewBox="0 0 1816 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Node game coverage: 14.06%">
+  <title>Node game coverage: 14.06%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="m"><rect width="1636" height="200" rx="30" fill="#FFF"/></mask>
+  <mask id="m"><rect width="1816" height="200" rx="30" fill="#FFF"/></mask>
   <g mask="url(#m)">
     <rect width="1276" height="200" fill="#555"/>
-    <rect width="360" height="200" fill="#0f80c1" x="1276"/>
-    <rect width="1636" height="200" fill="url(#a)"/>
+    <rect width="540" height="200" fill="#0f80c1" x="1276"/>
+    <rect width="1816" height="200" fill="url(#a)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="1176" fill="#000" opacity="0.25">Node game coverage</text>
     <text x="50" y="138" textLength="1176">Node game coverage</text>
-    <text x="1331" y="148" textLength="260" fill="#000" opacity="0.25">13%</text>
-    <text x="1321" y="138" textLength="260">13%</text>
+    <text x="1331" y="148" textLength="440" fill="#000" opacity="0.25">14.06%</text>
+    <text x="1321" y="138" textLength="440">14.06%</text>
   </g>
   
 </svg>

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -26,9 +26,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "gamedig/node-gamedig"
-          sparse-checkout: |
-            lib/games.js
-            package.json
           path: "node-gamedig"
 
       - name: Calculate comparison

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -7,7 +7,7 @@ on:
       - "src/games/definitions.rs"
       - ".github/workflows/node-badge.yml"
   schedule:
-    - cron: '0 0 * * 1' # Update once a week in case node-gamedig has changed
+    - cron: '34 3 * * 2' # Update once a week in case node-gamedig has changed
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           repository: "gamedig/node-gamedig"
           path: "node-gamedig"
+          sparse-checkout: |
+            lib/games.js
+            package.json
 
       - name: Calculate comparison
         id: comparison

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -26,30 +26,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: "gamedig/node-gamedig"
-          sparse-checkout: "games.txt"
+          sparse-checkout: |
+            lib/games.js
+            package.json
           path: "node-gamedig"
 
       - name: Calculate comparison
         id: comparison
-        run: |
-          # Find list of node games
-          node_games=$(awk -F "|" '/^[^#]/ {if(length($1) > 0) print $1 }' ./node-gamedig/games.txt)
-          node_games_count=$(printf "%s\n" "$node_games" | wc -l)
-
-          # Calculate how many of those games we have definitions for
-          rust_games_count=0
-          for game in $node_games; do
-            if grep "\"$game\" *=>" ./crates/lib/src/games/definitions.rs; then
-              rust_games_count=$(( rust_games_count + 1 ))
-            fi
-          done
-
-          # Calculate percent
-          percent=$(( rust_games_count * 100 / node_games_count))
-
-          echo "$rust_games_count/$node_games_count $percent%"
-          # Output percentage
-          echo "percent=$percent" >> "${GITHUB_OUTPUT}"
+        run: node .github/workflows/scripts/node-badge.mjs
 
       - name: Generate the badge SVG image
         uses: emibcn/badge-action@v2.0.2

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/games/definitions.rs"
       - ".github/workflows/node-badge.yml"
+      - ".github/workflows/scripts/node-badge.mjs"
   schedule:
     - cron: '34 3 * * 2' # Update once a week in case node-gamedig has changed
   workflow_dispatch:

--- a/.github/workflows/node-badge.yml
+++ b/.github/workflows/node-badge.yml
@@ -4,7 +4,7 @@ name: "Generate node comparison badge"
 on:
   push:
     paths:
-      - "src/games/definitions.rs"
+      - "crates/lib/src/games/definitions.rs"
       - ".github/workflows/node-badge.yml"
       - ".github/workflows/scripts/node-badge.mjs"
   schedule:

--- a/.github/workflows/scripts/node-badge.mjs
+++ b/.github/workflows/scripts/node-badge.mjs
@@ -15,8 +15,10 @@ const setOutput = (key, value) => {
 }
 
 // Get node IDs
-
-import { games } from "../../../node-gamedig/lib/index.js";
+// NOTE: Here we directly import from games to avoid loading
+//       unecessary parts of the library that would require us
+//       to install dependencies.
+import { games } from "../../../node-gamedig/lib/games.js";
 
 const node_ids = new Set(Object.keys(games));
 const node_total = node_ids.size;

--- a/.github/workflows/scripts/node-badge.mjs
+++ b/.github/workflows/scripts/node-badge.mjs
@@ -8,7 +8,7 @@ import process from "node:process";
 import { closeSync, openSync, writeSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
-function setOutput(key, value) {
+const setOutput = (key, value) => {
     const file = openSync(process.env.GITHUB_OUTPUT, "a");
     writeSync(file, `${key}=${value}\n`);
     closeSync(file);
@@ -16,7 +16,7 @@ function setOutput(key, value) {
 
 // Get node IDs
 
-import { games } from "../../../node-gamedig/lib/games.js";
+import { games } from "../../../node-gamedig/lib/index.js";
 
 const node_ids = new Set(Object.keys(games));
 const node_total = node_ids.size;

--- a/.github/workflows/scripts/node-badge.mjs
+++ b/.github/workflows/scripts/node-badge.mjs
@@ -1,0 +1,50 @@
+"use strict";
+
+//! Calculate the percentage of games from node that we support
+// Expects node-gamedig checkout out in git root /node-gamedig
+// Expects the generic example to output a list of game IDs when no arguments are provided
+
+import process from "node:process";
+import { closeSync, openSync, writeSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+function setOutput(key, value) {
+    const file = openSync(process.env.GITHUB_OUTPUT, "a");
+    writeSync(file, `${key}=${value}\n`);
+    closeSync(file);
+}
+
+// Get node IDs
+
+import { games } from "../../../node-gamedig/lib/games.js";
+
+const node_ids = new Set(Object.keys(games));
+const node_total = node_ids.size;
+
+// Get rust IDs
+
+const command = spawnSync("cargo", ["run", "-p", "gamedig", "--example", "generic"]);
+
+if (command.status !== 0) {
+    console.error(command.stderr.toString("utf8"));
+    process.exit(1);
+}
+
+const rust_ids_pretty = command.stdout.toString("utf8");
+const rust_ids = new Set(rust_ids_pretty.split("\n").map(line => line.split("\t")[0]).filter(id => id.length > 0));
+
+// Detect missing node IDs
+
+for (const id of rust_ids) {
+    if (node_ids.delete(id)) {
+        rust_ids.delete(id);
+    }
+}
+
+console.log("Node remains", node_ids);
+console.log("Rust remains", rust_ids);
+
+const percent = 1 - (node_ids.size / node_total);
+
+// Output percent to 2 decimal places
+setOutput("percent", Math.round(percent*10000)/100);


### PR DESCRIPTION
Fixes #155 using a new node script that should be more robust than the
old shell script.