### PR TITLE
Various improvements for the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Protocols:
 
 CLI:
 - Added a CLI (by @cainthebest).
+- Added DNS lookup support (by @Douile).
+- Added JSON output option (by @Douile).
+- Added ExtraRequestSettings as CLI arguments (by @Douile).
+- Added TimeoutSettings as CLI argument (by @Douile).
 
 ### Breaking:
 Game:

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,10 +12,13 @@ edition = "2021"
 
 [features]
 default = ["json"]
-json = ["dep:serde_json", "gamedig/serde"]
+json = ["dep:serde", "dep:serde_json", "gamedig/serde"]
 
 [dependencies]
 clap = { version = "4.1.11", features = ["derive"] }
 gamedig = { version = "*", path = "../lib", features = ["clap"] }
 thiserror = "1.0.43"
+
+# JSON dependencies
+serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,6 @@ json = ["dep:serde_json", "gamedig/serde"]
 
 [dependencies]
 clap = { version = "4.1.11", features = ["derive"] }
-gamedig = { version = "*", path = "../lib" }
+gamedig = { version = "*", path = "../lib", features = ["clap"] }
 thiserror = "1.0.43"
 serde_json = { version = "1", optional = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,7 +10,12 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["json"]
+json = ["dep:serde_json", "gamedig/serde"]
+
 [dependencies]
 clap = { version = "4.1.11", features = ["derive"] }
 gamedig = { version = "*", path = "../lib" }
 thiserror = "1.0.43"
+serde_json = { version = "1", optional = true }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -13,4 +13,7 @@ pub enum Error {
 
     #[error("Unknown Game: {0}")]
     UnknownGame(String),
+
+    #[error("Invalid hostname: {0}")]
+    InvalidHostname(String),
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,4 @@
-use std::net::ToSocketAddrs;
+use std::net::{IpAddr, ToSocketAddrs};
 
 use clap::Parser;
 use gamedig::{
@@ -53,6 +53,63 @@ fn find_game(game_id: &str) -> Result<&'static Game> {
         .ok_or_else(|| Error::UnknownGame(game_id.to_string()))
 }
 
+/// Resolve an IP address by either parsing an IP address or doing a DNS lookup.
+/// In the case of DNS lookup update extra request options with the hostname.
+///
+/// # Arguments
+/// * `host` - A string slice containing the IP address or hostname of a server
+///   to resolve.
+/// * `extra_options` - Mutable reference to extra options for the game query.
+///
+/// # Returns
+/// * `Result<IpAddr>` - On sucess returns a resolved IP address; on failure
+///   returns an [Error::InvalidHostname] error.
+fn resolve_ip_or_domain(host: &str, extra_options: &mut Option<ExtraRequestSettings>) -> Result<IpAddr> {
+    if let Ok(parsed_ip) = host.parse() {
+        Ok(parsed_ip)
+    } else {
+        set_hostname_if_missing(host, extra_options);
+
+        resolve_domain(host)
+    }
+}
+
+/// Resolve a domain name to one of its IP addresses (the first one returned).
+///
+/// # Arguments
+/// * `domain` - A string slice containing the domain name to lookup.
+///
+/// # Returns
+/// * `Result<IpAddr>` - On success, returns one of the resolved IP addresses;
+///   on failure returns an [Error::InvalidHostname] error.
+fn resolve_domain(domain: &str) -> Result<IpAddr> {
+    // Append a dummy port to perform socket address resolution and then extract the
+    // IP
+    Ok(format!("{}:0", domain)
+        .to_socket_addrs()
+        .map_err(|_| Error::InvalidHostname(domain.to_string()))?
+        .next()
+        .ok_or_else(|| Error::InvalidHostname(domain.to_string()))?
+        .ip())
+}
+
+/// Sets the hostname on extra request settings if it is not already set.
+///
+/// # Arguments
+/// * `host` - A string slice containing the hostname.
+/// * `extra_options` - A mutable reference to optional [ExtraRequestSettings].
+fn set_hostname_if_missing(host: &str, extra_options: &mut Option<ExtraRequestSettings>) {
+    if let Some(extra_options) = extra_options {
+        if extra_options.hostname.is_none() {
+            // If extra_options exists but hostname is None overwrite hostname in place
+            extra_options.hostname = Some(host.to_string())
+        }
+    } else {
+        // If extra_options is None create default settings with hostname
+        *extra_options = Some(ExtraRequestSettings::default().set_hostname(host.to_string()));
+    }
+}
+
 fn main() -> Result<()> {
     // Parse the command line arguments
     let args = Cli::parse();
@@ -60,37 +117,13 @@ fn main() -> Result<()> {
     // Retrieve the game based on the provided ID
     let game = find_game(&args.game)?;
 
-    let mut extra_request_settings = if let Some(extra) = args.extra_options {
-        extra
-    } else {
-        gamedig::protocols::ExtraRequestSettings::default()
-    };
+    // Extract extra options for use in setup
+    let mut extra_options = args.extra_options;
 
-    let ip = if let Ok(ip) = args.ip.parse() {
-        ip
-    } else {
-        // Set hostname in extra request settings
-        if extra_request_settings.hostname.is_none() {
-            extra_request_settings.hostname = Some(args.ip.clone());
-        }
+    // Resolve the IP address
+    let ip = resolve_ip_or_domain(&args.ip, &mut extra_options)?;
 
-        // Use ToSocketAddrs to do a DNS lookup
-        // unfortunatley this requires a format to add a port
-        format!("{}:0", args.ip)
-            .to_socket_addrs()
-            .map_err(|_| error::Error::InvalidHostname(args.ip.clone()))?
-            .next()
-            .ok_or(error::Error::InvalidHostname(args.ip))?
-            .ip()
-    };
-
-    let result = query_with_timeout_and_extra_settings(
-        game,
-        &ip,
-        args.port,
-        args.timeout_settings,
-        Some(extra_request_settings),
-    )?;
+    let result = query_with_timeout_and_extra_settings(game, &ip, args.port, args.timeout_settings, extra_options)?;
 
     #[cfg(feature = "json")]
     if args.json {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
 
     #[arg(short, long)]
     port: Option<u16>,
+
+    #[cfg(feature = "json")]
+    #[arg(short, long, help = "Output result as JSON")]
+    json: bool,
 }
 
 fn main() -> Result<()> {
@@ -41,7 +45,16 @@ fn main() -> Result<()> {
             .ip()
     };
 
-    println!("{:#?}", query(game, &ip, args.port)?.as_json());
+    let result = query(game, &ip, args.port)?;
+
+    #[cfg(feature = "json")]
+    if args.json {
+        serde_json::to_writer_pretty(std::io::stdout(), &result.as_json()).unwrap();
+    } else {
+        println!("{:#?}", result.as_original());
+    }
+    #[cfg(not(feature = "json"))]
+    println!("{:#?}", result.as_original());
 
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -69,31 +69,11 @@ fn main() -> Result<()> {
             .ip()
     };
 
-    // Clap will default unset timeouts to None, which we don't want
-    let timeout_settings = if let Some(user_timeout_settings) = args.timeout_settings {
-        let default_timeout_settings = TimeoutSettings::const_default();
-
-        Some(TimeoutSettings::new(
-            user_timeout_settings
-                .get_read()
-                .or(default_timeout_settings.get_read()),
-            user_timeout_settings
-                .get_write()
-                .or(default_timeout_settings.get_write()),
-            user_timeout_settings
-                .get_connect()
-                .or(default_timeout_settings.get_connect()),
-            user_timeout_settings.get_retries(),
-        )?)
-    } else {
-        None
-    };
-
     let result = query_with_timeout_and_extra_settings(
         game,
         &ip,
         args.port,
-        timeout_settings,
+        args.timeout_settings,
         Some(extra_request_settings),
     )?;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,8 +10,10 @@ mod error;
 
 use self::error::{Error, Result};
 
+// NOTE: For some reason without setting long_about here the doc comment for
+// ExtraRequestSettings gets set as the about for the CLI.
 #[derive(Debug, Parser)]
-#[command(author, version, about)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// Unique identifier of the game for which server information is being
     /// queried.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -39,11 +39,11 @@ struct Cli {
     output_mode: OutputMode,
 
     /// Optional timeout settings for the server query.
-    #[command(flatten)]
+    #[command(flatten, next_help_heading = "Timeouts")]
     timeout_settings: Option<TimeoutSettings>,
 
     /// Optional extra settings for the server query.
-    #[command(flatten)]
+    #[command(flatten, next_help_heading = "Query options")]
     extra_options: Option<ExtraRequestSettings>,
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,7 @@ use gamedig::{
 
 mod error;
 
-use self::error::Result;
+use self::error::{Error, Result};
 
 #[derive(Parser)]
 #[command(author, version, about)]
@@ -37,13 +37,28 @@ struct Cli {
     extra_options: Option<ExtraRequestSettings>,
 }
 
+/// Attempt to find a game from the [library game definitions](GAMES) based on
+/// its unique identifier.
+///
+/// # Arguments
+/// * `game_id` - A string slice containing the unique game identifier.
+///
+/// # Returns
+/// * Result<&'static [Game]> - On sucess returns a reference to the game
+///   definition; on failure returns a [Error::UnknownGame] error.
+fn find_game(game_id: &str) -> Result<&'static Game> {
+    // Attempt to retrieve the game from the predefined game list
+    GAMES
+        .get(game_id)
+        .ok_or_else(|| Error::UnknownGame(game_id.to_string()))
+}
+
 fn main() -> Result<()> {
+    // Parse the command line arguments
     let args = Cli::parse();
 
-    let game = match GAMES.get(&args.game) {
-        Some(game) => game,
-        None => return Err(error::Error::UnknownGame(args.game)),
-    };
+    // Retrieve the game based on the provided ID
+    let game = find_game(&args.game)?;
 
     let mut extra_request_settings = if let Some(extra) = args.extra_options {
         extra

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,29 +10,33 @@ mod error;
 
 use self::error::{Error, Result};
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(author, version, about)]
 struct Cli {
-    /// Game ID
+    /// Unique identifier of the game for which server information is being
+    /// queried.
     #[arg(short, long)]
     game: String,
 
-    /// Hostname or IP address of the server
+    /// Hostname or IP address of the server.
     #[arg(short, long)]
     ip: String,
 
-    /// Optional port number to override the default for the game
+    /// Optional query port number for the server. If not provided the default
+    /// port for the game is used.
     #[arg(short, long)]
     port: Option<u16>,
 
-    /// Output result as JSON
+    /// Flag indicating if the output should be in JSON format.
     #[cfg(feature = "json")]
     #[arg(short, long)]
     json: bool,
 
+    /// Optional timeout settings for the server query.
     #[command(flatten)]
     timeout_settings: Option<TimeoutSettings>,
 
+    /// Optional extra settings for the server query.
     #[command(flatten)]
     extra_options: Option<ExtraRequestSettings>,
 }
@@ -156,6 +160,8 @@ fn main() -> Result<()> {
     // Resolve the IP address
     let ip = resolve_ip_or_domain(&args.ip, &mut extra_options)?;
 
+    // Query the server using game definition, parsed IP, and user command line
+    // flags.
     let result = query_with_timeout_and_extra_settings(game, &ip, args.port, args.timeout_settings, extra_options)?;
 
     // Output the result in the specified format

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,17 +10,21 @@ use self::error::Result;
 #[derive(Parser)]
 #[command(author, version, about)]
 struct Cli {
+    /// Game ID
     #[arg(short, long)]
     game: String,
 
-    #[arg(short, long, help = "Hostname or IP address of the server")]
+    /// Hostname or IP address of the server
+    #[arg(short, long)]
     ip: String,
 
+    /// Optional port number to override the default for the game
     #[arg(short, long)]
     port: Option<u16>,
 
+    /// Output result as JSON
     #[cfg(feature = "json")]
-    #[arg(short, long, help = "Output result as JSON")]
+    #[arg(short, long)]
     json: bool,
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::net::ToSocketAddrs;
 
 use clap::Parser;
-use gamedig::{games::*, protocols::ExtraRequestSettings, GDErrorKind};
+use gamedig::{games::*, protocols::ExtraRequestSettings};
 
 mod error;
 
@@ -57,9 +57,9 @@ fn main() -> Result<()> {
         // unfortunatley this requires a format to add a port
         format!("{}:0", args.ip)
             .to_socket_addrs()
-            .map_err(|e| GDErrorKind::InvalidInput.context(e))?
+            .map_err(|_| error::Error::InvalidHostname(args.ip.clone()))?
             .next()
-            .ok_or(GDErrorKind::InvalidInput.context(format!("Could not resolve an IP address for {:?}", args.ip)))?
+            .ok_or(error::Error::InvalidHostname(args.ip))?
             .ip()
     };
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -22,6 +22,7 @@ games = []
 services = []
 game_defs = ["dep:phf", "games"]
 serde = ["dep:serde", "serde/derive"]
+clap = ["dep:clap"]
 
 [dependencies]
 byteorder = "1.5"
@@ -33,3 +34,5 @@ encoding_rs = "0.8"
 serde = { version = "1.0", optional = true }
 
 phf = { version = "0.11", optional = true, features = ["macros"] }
+
+clap = { version = "4.1.11", optional = true, features = ["derive"] }

--- a/crates/lib/src/games/minecraft/types.rs
+++ b/crates/lib/src/games/minecraft/types.rs
@@ -55,6 +55,7 @@ impl CommonPlayer for Player {
 }
 
 /// Versioned response type
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionedResponse<'a> {
     Bedrock(&'a BedrockResponse),

--- a/crates/lib/src/protocols/gamespy/mod.rs
+++ b/crates/lib/src/protocols/gamespy/mod.rs
@@ -17,6 +17,7 @@ pub enum GameSpyVersion {
 }
 
 /// Versioned response type
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionedResponse<'a> {
     One(&'a one::Response),
@@ -25,6 +26,7 @@ pub enum VersionedResponse<'a> {
 }
 
 /// Versioned player type
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionedPlayer<'a> {
     One(&'a one::Player),

--- a/crates/lib/src/protocols/quake/types.rs
+++ b/crates/lib/src/protocols/quake/types.rs
@@ -51,6 +51,7 @@ impl<P: QuakePlayerType> CommonResponse for Response<P> {
 }
 
 /// Versioned response type
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionedResponse<'a> {
     One(&'a Response<crate::protocols::quake::one::Player>),

--- a/crates/lib/src/protocols/types.rs
+++ b/crates/lib/src/protocols/types.rs
@@ -157,13 +157,14 @@ fn parse_duration_secs(value: &str) -> Result<Duration, std::num::ParseIntError>
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TimeoutSettings {
-    #[cfg_attr(feature = "clap", arg(long = "connect-timeout", value_parser = parse_duration_secs, help = "Socket connect timeout (in seconds)"))]
+    #[cfg_attr(feature = "clap", arg(long = "connect-timeout", value_parser = parse_duration_secs, help = "Socket connect timeout (in seconds)", default_value = "4"))]
     connect: Option<Duration>,
-    #[cfg_attr(feature = "clap", arg(long = "read-timeout", value_parser = parse_duration_secs, help = "Socket read timeout (in seconds)"))]
+    #[cfg_attr(feature = "clap", arg(long = "read-timeout", value_parser = parse_duration_secs, help = "Socket read timeout (in seconds)", default_value = "4"))]
     read: Option<Duration>,
-    #[cfg_attr(feature = "clap", arg(long = "write-timeout", value_parser = parse_duration_secs, help = "Socket write timeout (in seconds)"))]
+    #[cfg_attr(feature = "clap", arg(long = "write-timeout", value_parser = parse_duration_secs, help = "Socket write timeout (in seconds)", default_value = "4"))]
     write: Option<Duration>,
-    #[cfg_attr(feature = "clap", arg(long))]
+    /// Number of retries per request
+    #[cfg_attr(feature = "clap", arg(long, default_value = "0"))]
     retries: usize,
 }
 

--- a/crates/lib/src/protocols/types.rs
+++ b/crates/lib/src/protocols/types.rs
@@ -146,12 +146,22 @@ pub struct CommonPlayerJson<'a> {
     pub score: Option<i32>,
 }
 
+#[cfg(feature = "clap")]
+fn parse_duration_secs(value: &str) -> Result<Duration, std::num::ParseIntError> {
+    let secs = value.parse()?;
+    Ok(Duration::from_secs(secs))
+}
+
 /// Timeout settings for socket operations
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TimeoutSettings {
+    #[cfg_attr(feature = "clap", arg(long = "read-timeout", value_parser = parse_duration_secs, help = "Socket read timeout (in seconds)"))]
     read: Option<Duration>,
+    #[cfg_attr(feature = "clap", arg(long = "write-timeout", value_parser = parse_duration_secs, help = "Socket write timeout (in seconds)"))]
     write: Option<Duration>,
+    #[cfg_attr(feature = "clap", arg(long))]
     retries: usize,
 }
 

--- a/crates/lib/src/protocols/types.rs
+++ b/crates/lib/src/protocols/types.rs
@@ -251,32 +251,38 @@ impl Default for TimeoutSettings {
 /// let valve_settings: valve::GatheringSettings = ExtraRequestSettings::default().set_check_app_id(false).into();
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct ExtraRequestSettings {
     /// The server's hostname.
     ///
     /// Used by:
     /// - [minecraft::RequestSettings#structfield.hostname]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub hostname: Option<String>,
     /// The protocol version to use.
     ///
     /// Used by:
     /// - [minecraft::RequestSettings#structfield.protocol_version]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub protocol_version: Option<i32>,
     /// Whether to gather player information
     ///
     /// Used by:
     /// - [valve::GatheringSettings#structfield.players]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub gather_players: Option<bool>,
     /// Whether to gather rule information.
     ///
     /// Used by:
     /// - [valve::GatheringSettings#structfield.rules]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub gather_rules: Option<bool>,
     /// Whether to check if the App ID is valid.
     ///
     /// Used by:
     /// - [valve::GatheringSettings#structfield.check_app_id]
+    #[cfg_attr(feature = "clap", arg(long))]
     pub check_app_id: Option<bool>,
 }
 

--- a/crates/lib/src/protocols/types.rs
+++ b/crates/lib/src/protocols/types.rs
@@ -30,6 +30,7 @@ pub enum Protocol {
 }
 
 /// All response types
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum GenericResponse<'a> {
     GameSpy(gamespy::VersionedResponse<'a>),
@@ -47,6 +48,7 @@ pub enum GenericResponse<'a> {
 }
 
 /// All player types
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum GenericPlayer<'a> {
     Valve(&'a valve::ServerPlayer),


### PR DESCRIPTION
There was a bunch of things I wanted to add to the CLI so I put them in one PR.

- Added DNS lookup support
- Added JSON output option (and output the original response struct by default)
- Added ExtraRequestSettings as CLI arguments
- Added TimeoutSettings as CLI argument

If there's any that need more work or we don't want I can remove/split into other PR.

NOTE whichever of this or #158 gets merged first will cause issue with clap args.