### PR TITLE
Revert "Bump actions/labeler from 4 to 5 in /.github/workflows (#165)"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           dot: true


### PR DESCRIPTION
This reverts commit 04da29f2a6b11157524c170097db14232ef32813.

I tried to update the config in #166 but there seems to be a bug.

EDIT: This still used v5 in CI (maybe the config doesn't update until in main?)