### PR TITLE
chore: extract jc2m into multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Games:
 - [Squad](https://store.steampowered.com/app/393380/Squad/) support.
 - [Savage 2](https://savage2.net/) support.
 - Added a valve protocol query example.
+- Made all of Just Cause 2: Multiplayer Response and Player fields public.
 
 Protocols:
 - Added the unreal2 protocol and its associated games: Darkest Hour, Devastation, Killing Floor, Red Orchestra, Unreal Tournament 2003, Unreal Tournament 2004 (by @Douile).

--- a/crates/lib/src/games/jc2m/mod.rs
+++ b/crates/lib/src/games/jc2m/mod.rs
@@ -1,0 +1,8 @@
+/// The implementation.
+/// Reference: [Node-GameGig](https://github.com/gamedig/node-gamedig/blob/master/protocols/jc2mp.js)
+pub mod protocol;
+/// All types used by the implementation.
+pub mod types;
+
+pub use protocol::*;
+pub use types::*;

--- a/crates/lib/src/games/jc2m/types.rs
+++ b/crates/lib/src/games/jc2m/types.rs
@@ -1,0 +1,50 @@
+use crate::protocols::types::{CommonPlayer, CommonResponse, GenericPlayer};
+use crate::protocols::GenericResponse;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Player {
+    pub name: String,
+    pub steam_id: String,
+    pub ping: u16,
+}
+
+impl CommonPlayer for Player {
+    fn as_original(&self) -> GenericPlayer { GenericPlayer::JCMP2(self) }
+
+    fn name(&self) -> &str { &self.name }
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Response {
+    pub game_version: String,
+    pub description: String,
+    pub name: String,
+    pub has_password: bool,
+    pub players: Vec<Player>,
+    pub players_maximum: u32,
+    pub players_online: u32,
+}
+
+impl CommonResponse for Response {
+    fn as_original(&self) -> GenericResponse { GenericResponse::JC2M(self) }
+
+    fn game_version(&self) -> Option<&str> { Some(&self.game_version) }
+    fn description(&self) -> Option<&str> { Some(&self.description) }
+    fn name(&self) -> Option<&str> { Some(&self.name) }
+    fn has_password(&self) -> Option<bool> { Some(self.has_password) }
+    fn players_maximum(&self) -> u32 { self.players_maximum }
+    fn players_online(&self) -> u32 { self.players_online }
+
+    fn players(&self) -> Option<Vec<&dyn CommonPlayer>> {
+        Some(
+            self.players
+                .iter()
+                .map(|p| p as &dyn CommonPlayer)
+                .collect(),
+        )
+    }
+}


### PR DESCRIPTION
While making #135 I've seen that having everything of a proprietary protocol in a single file was being a bit too cluttered and I've extracted stuff into multiple files (`types` and `protocol`).

This would also apply for `FFOW` and `The Ship`, but I've decided to take some opinions on it.

This PR also makes all of jc2m's `response` and `player` fields public.