### PR TITLE
feat: http client and eco support

### DIFF
--- a/.github/badges/node.svg
+++ b/.github/badges/node.svg
@@ -1,5 +1,5 @@
-<svg width="181.6" height="20" viewBox="0 0 1816 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Node game coverage: 13.98%">
-  <title>Node game coverage: 13.98%</title>
+<svg width="181.6" height="20" viewBox="0 0 1816 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Node game coverage: 19.46%">
+  <title>Node game coverage: 19.46%</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="1176" fill="#000" opacity="0.25">Node game coverage</text>
     <text x="50" y="138" textLength="1176">Node game coverage</text>
-    <text x="1331" y="148" textLength="440" fill="#000" opacity="0.25">13.98%</text>
-    <text x="1321" y="138" textLength="440">13.98%</text>
+    <text x="1331" y="148" textLength="440" fill="#000" opacity="0.25">19.46%</text>
+    <text x="1321" y="138" textLength="440">19.46%</text>
   </g>
   
 </svg>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Games:
 - Added a valve protocol query example.
 - Made all of Just Cause 2: Multiplayer Response and Player fields public.
 - [Mindustry](https://mindustrygame.github.io/) support.
+- Eco support (by @CosminPerRam).
 
 Crate:
 - Changed the serde feature to only enable serde derive for some types: serde and serde_json is now a dependecy by default.
 
 Protocols:
 - Added the unreal2 protocol and its associated games: Darkest Hour, Devastation, Killing Floor, Red Orchestra, Unreal Tournament 2003, Unreal Tournament 2004 (by @Douile).
+- Added HTTPClient to allow use of HTTP(S) (and JSON) APIs (by @CosminPerRam & @Douile).
 
 CLI:
 - Added a CLI (by @cainthebest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Games:
 - Added a valve protocol query example.
 - Made all of Just Cause 2: Multiplayer Response and Player fields public.
 
+Crate:
+- Changed the serde feature to only enable serde derive for some types: serde and serde_json is now a dependecy by default.
+
 Protocols:
 - Added the unreal2 protocol and its associated games: Darkest Hour, Devastation, Killing Floor, Red Orchestra, Unreal Tournament 2003, Unreal Tournament 2004 (by @Douile).
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -29,7 +29,9 @@ byteorder = "1.5"
 bzip2-rs = "0.1"
 crc32fast = "1.3"
 serde_json = "1.0"
+serde_derive = "1.0"
 encoding_rs = "0.8"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 
 serde = { version = "1.0", optional = true }
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -74,5 +74,9 @@ name = "valve_master_server_query"
 required-features = ["services"]
 
 [[example]]
+name = "test_eco"
+required-features = ["games"]
+
+[[example]]
 name = "generic"
 required-features = ["games", "game_defs"]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -21,8 +21,9 @@ default = ["games", "services", "game_defs"]
 games = []
 services = []
 game_defs = ["dep:phf", "games"]
-serde = ["dep:serde", "serde/derive"]
+serde = ["dep:serde", "serde/derive", "ureq/json"]
 clap = ["dep:clap"]
+tls = ["ureq/tls"]
 
 [dependencies]
 byteorder = "1.5"
@@ -31,7 +32,8 @@ crc32fast = "1.3"
 serde_json = "1.0"
 serde_derive = "1.0"
 encoding_rs = "0.8"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+ureq = { version = "2.8", default-features = false, features = ["gzip"] }
+url = "2"
 
 serde = { version = "1.0", optional = true }
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -18,24 +18,35 @@ categories = ["parser-implementations", "parsing", "network-programming", "encod
 
 [features]
 default = ["games", "services", "game_defs"]
+
+# Enable query functions for specific games
 games = []
-services = []
+# Enable game definitions for use with the generic query functions
 game_defs = ["dep:phf", "games"]
-serde = ["dep:serde", "serde/derive", "ureq/json"]
+
+# Enable service querying
+services = []
+
+# Enable serde derivations for our types
+serde = []
+
+# Enable clap derivations for our types
 clap = ["dep:clap"]
+
+# Enable TLS for HTTP Client
 tls = ["ureq/tls"]
 
 [dependencies]
 byteorder = "1.5"
 bzip2-rs = "0.1"
 crc32fast = "1.3"
-serde_json = "1.0"
-serde_derive = "1.0"
+
 encoding_rs = "0.8"
-ureq = { version = "2.8", default-features = false, features = ["gzip"] }
+ureq = { version = "2.8", default-features = false, features = ["gzip", "json"] }
 url = "2"
 
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 
 phf = { version = "0.11", optional = true, features = ["macros"] }
 

--- a/crates/lib/examples/test_eco.rs
+++ b/crates/lib/examples/test_eco.rs
@@ -1,0 +1,10 @@
+use gamedig::games::eco;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+fn main() {
+    let ip = IpAddr::from_str("142.132.154.69").unwrap();
+    let port = 31111;
+    let r = eco::query(&ip, Some(port));
+    println!("{:#?}", r);
+}

--- a/crates/lib/src/errors/kind.rs
+++ b/crates/lib/src/errors/kind.rs
@@ -34,6 +34,8 @@ pub enum GDErrorKind {
     JsonParse,
     /// Couldn't parse a value.
     TypeParse,
+    /// Couldn't find the host specified.
+    HostLookup,
 }
 
 impl GDErrorKind {

--- a/crates/lib/src/games/definitions.rs
+++ b/crates/lib/src/games/definitions.rs
@@ -120,6 +120,5 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "redorchestra" => game!("Red Orchestra", 7759, Protocol::Unreal2),
     "unrealtournament2003" => game!("Unreal Tournament 2003", 7758, Protocol::Unreal2),
     "unrealtournament2004" => game!("Unreal Tournament 2004", 7778, Protocol::Unreal2),
-    #[cfg(feature = "serde")]
     "eco" => game!("Eco", 3000, Protocol::PROPRIETARY(ProprietaryProtocol::Eco)),
 };

--- a/crates/lib/src/games/definitions.rs
+++ b/crates/lib/src/games/definitions.rs
@@ -120,4 +120,5 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "redorchestra" => game!("Red Orchestra", 7759, Protocol::Unreal2),
     "unrealtournament2003" => game!("Unreal Tournament 2003", 7758, Protocol::Unreal2),
     "unrealtournament2004" => game!("Unreal Tournament 2004", 7778, Protocol::Unreal2),
+    "eco" => game!("Eco", 3000, Protocol::PROPRIETARY(ProprietaryProtocol::Eco)),
 };

--- a/crates/lib/src/games/definitions.rs
+++ b/crates/lib/src/games/definitions.rs
@@ -120,5 +120,6 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "redorchestra" => game!("Red Orchestra", 7759, Protocol::Unreal2),
     "unrealtournament2003" => game!("Unreal Tournament 2003", 7758, Protocol::Unreal2),
     "unrealtournament2004" => game!("Unreal Tournament 2004", 7778, Protocol::Unreal2),
+    #[cfg(feature = "serde")]
     "eco" => game!("Eco", 3000, Protocol::PROPRIETARY(ProprietaryProtocol::Eco)),
 };

--- a/crates/lib/src/games/eco/mod.rs
+++ b/crates/lib/src/games/eco/mod.rs
@@ -1,0 +1,8 @@
+/// The implementation.
+/// Reference: [Node-GameGig](https://github.com/gamedig/node-gamedig/blob/master/protocols/ffow.js)
+pub mod protocol;
+/// All types used by the implementation.
+pub mod types;
+
+pub use protocol::*;
+pub use types::*;

--- a/crates/lib/src/games/eco/protocol.rs
+++ b/crates/lib/src/games/eco/protocol.rs
@@ -1,5 +1,5 @@
-use crate::eco::{Response, Root};
-use crate::http::{HttpSettings, HttpClient, Protocol};
+use crate::eco::{EcoRequestSettings, Response, Root};
+use crate::http::HttpClient;
 use crate::{GDResult, TimeoutSettings};
 use std::net::{IpAddr, SocketAddr};
 
@@ -8,20 +8,27 @@ use std::net::{IpAddr, SocketAddr};
 pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> { query_with_timeout(address, port, &None) }
 
 /// Query a eco server.
+#[inline]
 pub fn query_with_timeout(
     address: &IpAddr,
     port: Option<u16>,
     timeout_settings: &Option<TimeoutSettings>,
 ) -> GDResult<Response> {
+    query_with_timeout_and_extra_settings(address, port, timeout_settings, None)
+}
+
+/// Query a eco server.
+pub fn query_with_timeout_and_extra_settings(
+    address: &IpAddr,
+    port: Option<u16>,
+    timeout_settings: &Option<TimeoutSettings>,
+    extra_settings: Option<EcoRequestSettings>,
+) -> GDResult<Response> {
     let address = &SocketAddr::new(*address, port.unwrap_or(3001));
     let mut client = HttpClient::new(
         address,
         timeout_settings,
-        HttpSettings::<&str> {
-            protocol: Protocol::Http,
-            hostname: None,
-            headers: vec![],
-        },
+        extra_settings.unwrap_or_default().into(),
     )?;
 
     let response = client.get_json::<Root>("/frontpage")?;

--- a/crates/lib/src/games/eco/protocol.rs
+++ b/crates/lib/src/games/eco/protocol.rs
@@ -1,13 +1,29 @@
 use crate::eco::{Response, Root};
-use crate::http::HttpClient;
+use crate::http::{HTTPSettings, HttpClient};
 use crate::{GDResult, TimeoutSettings};
 use std::net::{IpAddr, SocketAddr};
 
-pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
-    let address = &SocketAddr::new(*address, port.unwrap_or(3001));
-    let mut client = HttpClient::new(address, &Some(TimeoutSettings::default()))?;
+/// Query a eco server.
+#[inline]
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> { query_with_timeout(address, port, &None) }
 
-    let response = client.request::<Root>("/frontpage")?;
+/// Query a eco server.
+pub fn query_with_timeout(
+    address: &IpAddr,
+    port: Option<u16>,
+    timeout_settings: &Option<TimeoutSettings>,
+) -> GDResult<Response> {
+    let address = &SocketAddr::new(*address, port.unwrap_or(3001));
+    let mut client = HttpClient::new(
+        address,
+        timeout_settings,
+        HTTPSettings {
+            protocol: crate::http::Protocol::HTTP,
+            hostname: None,
+        },
+    )?;
+
+    let response = client.get_json::<Root>("/frontpage")?;
 
     Ok(response.into())
 }

--- a/crates/lib/src/games/eco/protocol.rs
+++ b/crates/lib/src/games/eco/protocol.rs
@@ -1,5 +1,5 @@
 use crate::eco::{Response, Root};
-use crate::http::{HTTPSettings, HttpClient};
+use crate::http::{HTTPSettings, HttpClient, Protocol};
 use crate::{GDResult, TimeoutSettings};
 use std::net::{IpAddr, SocketAddr};
 
@@ -18,7 +18,7 @@ pub fn query_with_timeout(
         address,
         timeout_settings,
         HTTPSettings {
-            protocol: crate::http::Protocol::HTTP,
+            protocol: Protocol::Http,
             hostname: None,
         },
     )?;

--- a/crates/lib/src/games/eco/protocol.rs
+++ b/crates/lib/src/games/eco/protocol.rs
@@ -1,5 +1,5 @@
 use crate::eco::{Response, Root};
-use crate::http::{HTTPSettings, HttpClient, Protocol};
+use crate::http::{HttpSettings, HttpClient, Protocol};
 use crate::{GDResult, TimeoutSettings};
 use std::net::{IpAddr, SocketAddr};
 
@@ -17,9 +17,10 @@ pub fn query_with_timeout(
     let mut client = HttpClient::new(
         address,
         timeout_settings,
-        HTTPSettings {
+        HttpSettings::<&str> {
             protocol: Protocol::Http,
             hostname: None,
+            headers: vec![],
         },
     )?;
 

--- a/crates/lib/src/games/eco/protocol.rs
+++ b/crates/lib/src/games/eco/protocol.rs
@@ -1,0 +1,13 @@
+use crate::eco::{Response, Root};
+use crate::http::HttpClient;
+use crate::{GDResult, TimeoutSettings};
+use std::net::{IpAddr, SocketAddr};
+
+pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<Response> {
+    let address = &SocketAddr::new(*address, port.unwrap_or(3001));
+    let mut client = HttpClient::new(address, &Some(TimeoutSettings::default()))?;
+
+    let response = client.request::<Root>("/frontpage")?;
+
+    Ok(response.into())
+}

--- a/crates/lib/src/games/eco/types.rs
+++ b/crates/lib/src/games/eco/types.rs
@@ -1,0 +1,190 @@
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
+use std::collections::HashMap;
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Root {
+    #[serde(rename = "Info")]
+    pub info: Info,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Info {
+    #[serde(rename = "External")]
+    pub external: bool,
+    #[serde(rename = "GamePort")]
+    pub game_port: u32,
+    #[serde(rename = "WebPort")]
+    pub web_port: u32,
+    #[serde(rename = "IsLAN")]
+    pub is_lan: bool,
+    #[serde(rename = "Description")]
+    pub description: String,
+    #[serde(rename = "DetailedDescription")]
+    pub detailed_description: String,
+    #[serde(rename = "Category")]
+    pub category: String,
+    #[serde(rename = "OnlinePlayers")]
+    pub online_players: u32,
+    #[serde(rename = "TotalPlayers")]
+    pub total_players: u32,
+    #[serde(rename = "OnlinePlayersNames")]
+    pub online_players_names: Vec<String>,
+    #[serde(rename = "AdminOnline")]
+    pub admin_online: bool,
+    #[serde(rename = "TimeSinceStart")]
+    pub time_since_start: f64,
+    #[serde(rename = "TimeLeft")]
+    pub time_left: f64,
+    #[serde(rename = "Animals")]
+    pub animals: u32,
+    #[serde(rename = "Plants")]
+    pub plants: u32,
+    #[serde(rename = "Laws")]
+    pub laws: u32,
+    #[serde(rename = "WorldSize")]
+    pub world_size: String,
+    #[serde(rename = "Version")]
+    pub version: String,
+    #[serde(rename = "EconomyDesc")]
+    pub economy_desc: String,
+    #[serde(rename = "SkillSpecializationSetting")]
+    pub skill_specialization_setting: String,
+    #[serde(rename = "Language")]
+    pub language: String,
+    #[serde(rename = "HasPassword")]
+    pub has_password: bool,
+    #[serde(rename = "HasMeteor")]
+    pub has_meteor: bool,
+    #[serde(rename = "DistributionStationItems")]
+    pub distribution_station_items: String,
+    #[serde(rename = "Playtimes")]
+    pub playtimes: String,
+    #[serde(rename = "DiscordAddress")]
+    pub discord_address: String,
+    #[serde(rename = "IsPaused")]
+    pub is_paused: bool,
+    #[serde(rename = "ActiveAndOnlinePlayers")]
+    pub active_and_online_players: u32,
+    #[serde(rename = "PeakActivePlayers")]
+    pub peak_active_players: u32,
+    #[serde(rename = "MaxActivePlayers")]
+    pub max_active_players: u32,
+    #[serde(rename = "ShelfLifeMultiplier")]
+    pub shelf_life_multiplier: f64,
+    #[serde(rename = "ExhaustionAfterHours")]
+    pub exhaustion_after_hours: f64,
+    #[serde(rename = "IsLimitingHours")]
+    pub is_limiting_hours: bool,
+    #[serde(rename = "ServerAchievementsDict")]
+    pub server_achievements_dict: HashMap<String, String>,
+    #[serde(rename = "RelayAddress")]
+    pub relay_address: String,
+    #[serde(rename = "Access")]
+    pub access: String,
+    #[serde(rename = "JoinUrl")]
+    pub join_url: String,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Player {
+    pub name: String,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Response {
+    pub external: bool,
+    pub port: u32,
+    pub query_port: u32,
+    pub is_lan: bool,
+    pub description: String, // this and other fields require some text filtering
+    pub description_detailed: String,
+    pub description_economy: String,
+    pub category: String,
+    pub players_online: u32,
+    pub players_maximum: u32,
+    pub players: Vec<Player>,
+    pub admin_online: bool,
+    pub time_since_start: f64,
+    pub time_left: f64,
+    pub animals: u32,
+    pub plants: u32,
+    pub laws: u32,
+    pub world_size: String,
+    pub game_version: String,
+    pub skill_specialization_setting: String,
+    pub language: String,
+    pub has_password: bool,
+    pub has_meteor: bool,
+    pub distribution_station_items: String,
+    pub playtimes: String,
+    pub discord_address: String,
+    pub is_paused: bool,
+    pub active_and_online_players: u32,
+    pub peak_active_players: u32,
+    pub max_active_players: u32,
+    pub shelf_life_multiplier: f64,
+    pub exhaustion_after_hours: f64,
+    pub is_limiting_hours: bool,
+    pub server_achievements_dict: HashMap<String, String>,
+    pub relay_address: String,
+    pub access: String,
+    pub connect: String,
+}
+
+impl From<Root> for Response {
+    fn from(root: Root) -> Self {
+        let value = root.info;
+        Self {
+            external: value.external,
+            port: value.game_port,
+            query_port: value.web_port,
+            is_lan: value.is_lan,
+            description: value.description,
+            description_detailed: value.detailed_description,
+            description_economy: value.economy_desc,
+            category: value.category,
+            players_online: value.online_players,
+            players_maximum: value.total_players,
+            players: value
+                .online_players_names
+                .iter()
+                .map(|player| {
+                    Player {
+                        name: player.clone(),
+                    }
+                })
+                .collect(),
+            admin_online: value.admin_online,
+            time_since_start: value.time_since_start,
+            time_left: value.time_left,
+            animals: value.animals,
+            plants: value.plants,
+            laws: value.laws,
+            world_size: value.world_size,
+            game_version: value.version,
+            skill_specialization_setting: value.skill_specialization_setting,
+            language: value.language,
+            has_password: value.has_password,
+            has_meteor: value.has_meteor,
+            distribution_station_items: value.distribution_station_items,
+            playtimes: value.playtimes,
+            discord_address: value.discord_address,
+            is_paused: value.is_paused,
+            active_and_online_players: value.active_and_online_players,
+            peak_active_players: value.peak_active_players,
+            max_active_players: value.max_active_players,
+            shelf_life_multiplier: value.shelf_life_multiplier,
+            exhaustion_after_hours: value.exhaustion_after_hours,
+            is_limiting_hours: value.is_limiting_hours,
+            server_achievements_dict: value.server_achievements_dict,
+            relay_address: value.relay_address,
+            access: value.access,
+            connect: value.join_url,
+        }
+    }
+}

--- a/crates/lib/src/games/eco/types.rs
+++ b/crates/lib/src/games/eco/types.rs
@@ -2,6 +2,9 @@ use serde_derive::Deserialize;
 use serde_derive::Serialize;
 use std::collections::HashMap;
 
+use crate::protocols::types::CommonPlayer;
+use crate::protocols::types::CommonResponse;
+
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Root {
@@ -92,6 +95,14 @@ pub struct Info {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Player {
     pub name: String,
+}
+
+impl CommonPlayer for Player {
+    fn as_original(&self) -> crate::protocols::types::GenericPlayer {
+        crate::protocols::types::GenericPlayer::Eco(self)
+    }
+
+    fn name(&self) -> &str { &self.name }
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -187,4 +198,20 @@ impl From<Root> for Response {
             connect: value.join_url,
         }
     }
+}
+
+impl CommonResponse for Response {
+    fn as_original(&self) -> crate::protocols::GenericResponse { crate::protocols::GenericResponse::Eco(self) }
+
+    fn players_online(&self) -> u32 { self.players_online }
+
+    fn players_maximum(&self) -> u32 { self.players_maximum }
+
+    fn description(&self) -> Option<&str> { Some(&self.description) }
+
+    fn game_version(&self) -> Option<&str> { Some(&self.game_version) }
+
+    fn has_password(&self) -> Option<bool> { Some(self.has_password) }
+
+    fn players(&self) -> Option<Vec<&dyn CommonPlayer>> { Some(self.players.iter().map(|p| p as _).collect()) }
 }

--- a/crates/lib/src/games/eco/types.rs
+++ b/crates/lib/src/games/eco/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::http::HttpSettings;
+use crate::http::{HttpProtocol, HttpSettings};
 use crate::protocols::types::{CommonPlayer, CommonResponse};
 use crate::ExtraRequestSettings;
 
@@ -233,7 +233,7 @@ impl From<ExtraRequestSettings> for EcoRequestSettings {
 impl From<EcoRequestSettings> for HttpSettings<String> {
     fn from(value: EcoRequestSettings) -> Self {
         HttpSettings {
-            protocol: crate::http::Protocol::Http,
+            protocol: HttpProtocol::Http,
             hostname: value.hostname,
             headers: Vec::with_capacity(0),
         }

--- a/crates/lib/src/games/eco/types.rs
+++ b/crates/lib/src/games/eco/types.rs
@@ -1,9 +1,9 @@
-use serde_derive::Deserialize;
-use serde_derive::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::protocols::types::CommonPlayer;
-use crate::protocols::types::CommonResponse;
+use crate::http::HttpSettings;
+use crate::protocols::types::{CommonPlayer, CommonResponse};
+use crate::ExtraRequestSettings;
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -214,4 +214,28 @@ impl CommonResponse for Response {
     fn has_password(&self) -> Option<bool> { Some(self.has_password) }
 
     fn players(&self) -> Option<Vec<&dyn CommonPlayer>> { Some(self.players.iter().map(|p| p as _).collect()) }
+}
+
+/// Extra request settings for eco queries.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct EcoRequestSettings {
+    hostname: Option<String>,
+}
+
+impl From<ExtraRequestSettings> for EcoRequestSettings {
+    fn from(value: ExtraRequestSettings) -> Self {
+        EcoRequestSettings {
+            hostname: value.hostname,
+        }
+    }
+}
+
+impl From<EcoRequestSettings> for HttpSettings<String> {
+    fn from(value: EcoRequestSettings) -> Self {
+        HttpSettings {
+            protocol: crate::http::Protocol::Http,
+            hostname: value.hostname,
+            headers: Vec::with_capacity(0),
+        }
+    }
 }

--- a/crates/lib/src/games/mod.rs
+++ b/crates/lib/src/games/mod.rs
@@ -13,7 +13,6 @@ pub use valve::*;
 /// Battalion 1944
 pub mod battalion1944;
 /// Eco
-#[cfg(feature = "serde")]
 pub mod eco;
 /// Frontlines: Fuel of War
 pub mod ffow;

--- a/crates/lib/src/games/mod.rs
+++ b/crates/lib/src/games/mod.rs
@@ -12,6 +12,8 @@ pub use valve::*;
 
 /// Battalion 1944
 pub mod battalion1944;
+/// Eco
+pub mod eco;
 /// Frontlines: Fuel of War
 pub mod ffow;
 /// Just Cause 2: Multiplayer

--- a/crates/lib/src/games/mod.rs
+++ b/crates/lib/src/games/mod.rs
@@ -13,6 +13,7 @@ pub use valve::*;
 /// Battalion 1944
 pub mod battalion1944;
 /// Eco
+#[cfg(feature = "serde")]
 pub mod eco;
 /// Frontlines: Fuel of War
 pub mod ffow;

--- a/crates/lib/src/games/query.rs
+++ b/crates/lib/src/games/query.rs
@@ -3,12 +3,12 @@
 use std::net::{IpAddr, SocketAddr};
 
 use crate::games::types::Game;
-use crate::games::{ffow, jc2m, minecraft, savage2, theship};
+use crate::games::{eco, ffow, jc2m, minecraft, savage2, theship};
+use crate::protocols;
 use crate::protocols::gamespy::GameSpyVersion;
 use crate::protocols::quake::QuakeVersion;
 use crate::protocols::types::{CommonResponse, ExtraRequestSettings, ProprietaryProtocol, Protocol, TimeoutSettings};
 use crate::GDResult;
-use crate::{eco, protocols};
 
 /// Make a query given a game definition
 #[inline]

--- a/crates/lib/src/games/query.rs
+++ b/crates/lib/src/games/query.rs
@@ -112,7 +112,15 @@ pub fn query_with_timeout_and_extra_settings(
                     }
                 }
                 #[cfg(feature = "serde")]
-                ProprietaryProtocol::Eco => eco::query_with_timeout(address, port, &timeout_settings).map(Box::new)?,
+                ProprietaryProtocol::Eco => {
+                    eco::query_with_timeout_and_extra_settings(
+                        address,
+                        port,
+                        &timeout_settings,
+                        extra_settings.map(ExtraRequestSettings::into),
+                    )
+                    .map(Box::new)?
+                }
             }
         }
     })

--- a/crates/lib/src/games/query.rs
+++ b/crates/lib/src/games/query.rs
@@ -111,7 +111,6 @@ pub fn query_with_timeout_and_extra_settings(
                         }
                     }
                 }
-                #[cfg(feature = "serde")]
                 ProprietaryProtocol::Eco => {
                     eco::query_with_timeout_and_extra_settings(
                         address,

--- a/crates/lib/src/games/query.rs
+++ b/crates/lib/src/games/query.rs
@@ -4,11 +4,11 @@ use std::net::{IpAddr, SocketAddr};
 
 use crate::games::types::Game;
 use crate::games::{ffow, jc2m, minecraft, savage2, theship};
-use crate::protocols;
 use crate::protocols::gamespy::GameSpyVersion;
 use crate::protocols::quake::QuakeVersion;
 use crate::protocols::types::{CommonResponse, ExtraRequestSettings, ProprietaryProtocol, Protocol, TimeoutSettings};
 use crate::GDResult;
+use crate::{eco, protocols};
 
 /// Make a query given a game definition
 #[inline]
@@ -111,6 +111,8 @@ pub fn query_with_timeout_and_extra_settings(
                         }
                     }
                 }
+                #[cfg(feature = "serde")]
+                ProprietaryProtocol::Eco => eco::query_with_timeout(address, port, &timeout_settings).map(Box::new)?,
             }
         }
     })

--- a/crates/lib/src/http.rs
+++ b/crates/lib/src/http.rs
@@ -20,9 +20,9 @@ pub struct HttpClient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum Protocol {
     #[default]
-    HTTP,
+    Http,
     #[cfg(feature = "tls")]
-    HTTPS,
+    Https,
 }
 
 impl Protocol {
@@ -31,9 +31,9 @@ impl Protocol {
     pub const fn as_str(&self) -> &'static str {
         use Protocol::*;
         match self {
-            HTTP => "http:",
+            Http => "http:",
             #[cfg(feature = "tls")]
-            HTTPS => "https:",
+            Https => "https:",
         }
     }
 }

--- a/crates/lib/src/http.rs
+++ b/crates/lib/src/http.rs
@@ -1,0 +1,37 @@
+use crate::GDErrorKind::{PacketSend, ProtocolFormat, SocketConnect};
+use crate::{GDResult, TimeoutSettings};
+use reqwest::blocking::*;
+use serde::de::DeserializeOwned;
+use std::net::SocketAddr;
+
+pub struct HttpClient {
+    client: Client,
+    address: String,
+}
+
+impl HttpClient {
+    pub fn new(address: &SocketAddr, timeout_settings: &Option<TimeoutSettings>) -> GDResult<Self>
+    where Self: Sized {
+        let client = Client::builder()
+            .connect_timeout(TimeoutSettings::get_connect_or_default(timeout_settings))
+            .timeout(TimeoutSettings::get_connect_or_default(timeout_settings))
+            .build()
+            .map_err(|e| SocketConnect.context(e))?;
+
+        Ok(Self {
+            client,
+            address: format!("http://{}:{}", address.ip(), address.port()),
+        })
+    }
+
+    pub fn concat_path(&self, path: &str) -> String { format!("{}{}", self.address, path) }
+
+    pub fn request<T: DeserializeOwned>(&mut self, path: &str) -> GDResult<T> {
+        self.client
+            .get(self.concat_path(path))
+            .send()
+            .map_err(|e| PacketSend.context(e))?
+            .json::<T>()
+            .map_err(|e| ProtocolFormat.context(e))
+    }
+}

--- a/crates/lib/src/http.rs
+++ b/crates/lib/src/http.rs
@@ -7,7 +7,6 @@ use std::net::SocketAddr;
 use ureq::{Agent, AgentBuilder};
 use url::Url;
 
-#[cfg(feature = "serde")]
 use serde::{de::DeserializeOwned, Serialize};
 
 /// Max length of HTTP responses in bytes: 1GB
@@ -171,11 +170,9 @@ impl HttpClient {
     pub fn get(&mut self, path: &str) -> GDResult<Vec<u8>> { self.request("GET", path) }
 
     /// Send a HTTP GET request and parse the JSON resonse.
-    #[cfg(feature = "serde")]
     pub fn get_json<T: DeserializeOwned>(&mut self, path: &str) -> GDResult<T> { self.request_json("GET", path) }
 
     /// Send a HTTP Post request with JSON data and parse a JSON response.
-    #[cfg(feature = "serde")]
     pub fn post_json<T: DeserializeOwned, S: Serialize>(&mut self, path: &str, data: S) -> GDResult<T> {
         self.request_with_json_data("POST", path, data)
     }
@@ -219,7 +216,6 @@ impl HttpClient {
 
     /// Send a HTTP request without any data and parse the JSON response.
     #[inline]
-    #[cfg(feature = "serde")]
     fn request_json<T: DeserializeOwned>(&mut self, method: &str, path: &str) -> GDResult<T> {
         // Append the path to the pre-parsed URL and create a request object.
         self.address.set_path(path);
@@ -240,7 +236,6 @@ impl HttpClient {
 
     /// Send a HTTP request with JSON data and parse the JSON response.
     #[inline]
-    #[cfg(feature = "serde")]
     fn request_with_json_data<T: DeserializeOwned, S: Serialize>(
         &mut self,
         method: &str,

--- a/crates/lib/src/http.rs
+++ b/crates/lib/src/http.rs
@@ -1,37 +1,156 @@
-use crate::GDErrorKind::{PacketSend, ProtocolFormat, SocketConnect};
+use crate::GDErrorKind::{InvalidInput, PacketSend, ProtocolFormat};
 use crate::{GDResult, TimeoutSettings};
-use reqwest::blocking::*;
-use serde::de::DeserializeOwned;
+
 use std::net::SocketAddr;
 
+use ureq::{Agent, AgentBuilder};
+use url::Url;
+
+#[cfg(feature = "serde")]
+use serde::{de::DeserializeOwned, Serialize};
+
+/// HTTP request client. Define parameters host parameters on new, then re-use
+/// for each request.
 pub struct HttpClient {
-    client: Client,
-    address: String,
+    client: Agent,
+    address: Url,
+}
+
+/// HTTP Protocols.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum Protocol {
+    #[default]
+    HTTP,
+    #[cfg(feature = "tls")]
+    HTTPS,
+}
+
+impl Protocol {
+    /// Convert [Protocol] to a static str for use in a [Url].
+    /// e.g. "http:"
+    pub const fn as_str(&self) -> &'static str {
+        use Protocol::*;
+        match self {
+            HTTP => "http:",
+            #[cfg(feature = "tls")]
+            HTTPS => "https:",
+        }
+    }
+}
+
+/// Additional settings for HTTPClients.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct HTTPSettings {
+    /// Choose whether to use HTTP or HTTPS.
+    pub protocol: Protocol,
+    /// Choose a hostname override (used to set the [Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header) and for TLS.
+    pub hostname: Option<String>,
 }
 
 impl HttpClient {
-    pub fn new(address: &SocketAddr, timeout_settings: &Option<TimeoutSettings>) -> GDResult<Self>
-    where Self: Sized {
-        let client = Client::builder()
-            .connect_timeout(TimeoutSettings::get_connect_or_default(timeout_settings))
-            .timeout(TimeoutSettings::get_connect_or_default(timeout_settings))
-            .build()
-            .map_err(|e| SocketConnect.context(e))?;
+    /// Creates a new HTTPClient that can be used to send requests.
+    ///
+    /// # Parameters
+    /// - [address](SocketAddr): The IP and port the HTTP request will connect
+    ///   to.
+    /// - [timeout_settings](TimeoutSettings): Used to set the connect and
+    ///   socket timeouts for the requests.
+    /// - [http_settings](HttpSettings): Additional settings for the HTTPClient.
+    pub fn new(
+        address: &SocketAddr,
+        timeout_settings: &Option<TimeoutSettings>,
+        http_settings: HTTPSettings,
+    ) -> GDResult<Self>
+    where
+        Self: Sized,
+    {
+        let mut client_builder = AgentBuilder::new();
+
+        // Set timeout settings
+        let (read_timeout, write_timeout) = TimeoutSettings::get_read_and_write_or_defaults(timeout_settings);
+
+        if let Some(read_timeout) = read_timeout {
+            client_builder = client_builder.timeout_read(read_timeout);
+        }
+
+        if let Some(write_timeout) = write_timeout {
+            client_builder = client_builder.timeout_write(write_timeout);
+        }
+
+        if let Some(connect_timeout) = TimeoutSettings::get_connect_or_default(timeout_settings) {
+            client_builder = client_builder.timeout_connect(connect_timeout);
+        }
+
+        // Every request sent from this client will connect to the address set
+        {
+            let address = *address;
+            client_builder = client_builder.resolver(move |_: &str| Ok(vec![address]));
+        }
+
+        // Set a friendly user-agent string
+        client_builder = client_builder.user_agent(concat!(
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION")
+        ));
+
+        let client = client_builder.build();
+
+        let host = http_settings.hostname.unwrap_or(address.ip().to_string());
 
         Ok(Self {
             client,
-            address: format!("http://{}:{}", address.ip(), address.port()),
+            // TODO: Use Url from_parts if it gets added
+            address: Url::parse(&format!(
+                "{}//{}:{}",
+                http_settings.protocol.as_str(),
+                host,
+                address.port()
+            ))
+            .map_err(|e| InvalidInput.context(e))?,
         })
     }
 
-    pub fn concat_path(&self, path: &str) -> String { format!("{}{}", self.address, path) }
+    /// Send a HTTP GET request and parse the JSON resonse.
+    #[cfg(feature = "serde")]
+    pub fn get_json<T: DeserializeOwned>(&mut self, path: &str) -> GDResult<T> { self.request_json("GET", path) }
 
-    pub fn request<T: DeserializeOwned>(&mut self, path: &str) -> GDResult<T> {
+    /// Send a HTTP Post request with JSON data and parse a JSON response.
+    #[cfg(feature = "serde")]
+    pub fn post_json<T: DeserializeOwned, S: Serialize>(&mut self, path: &str, data: S) -> GDResult<T> {
+        self.request_with_json_data("POST", path, data)
+    }
+
+    // NOTE: More methods can be added here as required
+
+    /// Send a HTTP request without any data and parse the JSON response.
+    #[inline]
+    #[cfg(feature = "serde")]
+    fn request_json<T: DeserializeOwned>(&mut self, method: &str, path: &str) -> GDResult<T> {
+        self.address.set_path(path);
         self.client
-            .get(self.concat_path(path))
-            .send()
+            .request_url(method, &self.address)
+            .call()
             .map_err(|e| PacketSend.context(e))?
-            .json::<T>()
+            .into_json::<T>()
+            .map_err(|e| ProtocolFormat.context(e))
+    }
+
+    /// Send a HTTP request with JSON data and parse the JSON response.
+    #[inline]
+    #[cfg(feature = "serde")]
+    fn request_with_json_data<T: DeserializeOwned, S: Serialize>(
+        &mut self,
+        method: &str,
+        path: &str,
+        data: S,
+    ) -> GDResult<T> {
+        self.address.set_path(path);
+        self.client
+            .request_url(method, &self.address)
+            .send_json(data)
+            .map_err(|e| PacketSend.context(e))?
+            .into_json::<T>()
             .map_err(|e| ProtocolFormat.context(e))
     }
 }

--- a/crates/lib/src/http.rs
+++ b/crates/lib/src/http.rs
@@ -27,18 +27,18 @@ pub struct HttpClient {
 ///
 /// Note: if the `tls` feature is disabled this will only contain Http.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum Protocol {
+pub enum HttpProtocol {
     #[default]
     Http,
     #[cfg(feature = "tls")]
     Https,
 }
 
-impl Protocol {
+impl HttpProtocol {
     /// Convert [Protocol] to a static str for use in a [Url].
     /// e.g. "http:"
     pub const fn as_str(&self) -> &'static str {
-        use Protocol::*;
+        use HttpProtocol::*;
         match self {
             Http => "http:",
             #[cfg(feature = "tls")]
@@ -61,7 +61,7 @@ impl Protocol {
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct HttpSettings<S: Into<String>> {
     /// Choose whether to use HTTP or HTTPS.
-    pub protocol: Protocol,
+    pub protocol: HttpProtocol,
     /// Choose a hostname override (used to set the [Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header) and for TLS.
     pub hostname: Option<S>,
     /// Choose HTTP headers to send with requests.
@@ -70,7 +70,7 @@ pub struct HttpSettings<S: Into<String>> {
 
 impl<S: Into<String>> HttpSettings<S> {
     /// Set the HTTP protocol (defaults to HTTP).
-    pub const fn protocol(mut self, protocol: Protocol) -> HttpSettings<S> {
+    pub const fn protocol(mut self, protocol: HttpProtocol) -> HttpSettings<S> {
         self.protocol = protocol;
         self
     }
@@ -273,9 +273,9 @@ mod tests {
         const HOSTNAME: &str = "example.org";
 
         #[cfg(feature = "tls")]
-        const PROTOCOL: Protocol = Protocol::Https;
+        const PROTOCOL: HttpProtocol = HttpProtocol::Https;
         #[cfg(not(feature = "tls"))]
-        const PROTOCOL: Protocol = Protocol::Http;
+        const PROTOCOL: HttpProtocol = HttpProtocol::Http;
 
         let settings = HttpSettings::default()
             .hostname(HOSTNAME)
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn http_client_new() {
-        const PROTOCOL: Protocol = Protocol::Http;
+        const PROTOCOL: HttpProtocol = HttpProtocol::Http;
 
         const ADDRESS: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8000));
 
@@ -321,7 +321,7 @@ mod tests {
             .unwrap();
 
         let settings = HttpSettings::default()
-            .protocol(Protocol::Https)
+            .protocol(HttpProtocol::Https)
             .hostname("api.github.com");
 
         let mut client = HttpClient::new(&address, &None, settings).unwrap();

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -28,11 +28,14 @@
 //! # Crate features:
 //! Enabled by default: `games`, `game_defs`, `services`
 //!
-//! `serde` - enables json serialization/deserialization for all response types.
-//! <br> `games` - include games support. <br>
+//! `serde` - enables serde serialization/deserialization for many gamedig types
+//! using serde derive. <br>
+//! `games` - include games support. <br>
 //! `services` - include services support. <br>
-//! `game_defs` - Include game definitions for programmatic access (enabled by
-//! default).
+//! `game_defs` - include game definitions for programmatic access (enabled by
+//! default). <br>
+//! `clap` - enable clap derivations for gamedig settings types. <br>
+//! `tls` - enable TLS support for the HTTP client.
 
 pub mod errors;
 #[cfg(feature = "games")]

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -42,6 +42,7 @@ pub mod protocols;
 pub mod services;
 
 mod buffer;
+mod http;
 mod socket;
 mod utils;
 

--- a/crates/lib/src/protocols/types.rs
+++ b/crates/lib/src/protocols/types.rs
@@ -19,6 +19,8 @@ pub enum ProprietaryProtocol {
     FFOW,
     JC2M,
     Savage2,
+    #[cfg(feature = "serde")]
+    Eco,
 }
 
 /// Enumeration of all valid protocol types
@@ -51,6 +53,8 @@ pub enum GenericResponse<'a> {
     JC2M(&'a crate::games::jc2m::Response),
     #[cfg(feature = "games")]
     Savage2(&'a crate::games::savage2::Response),
+    #[cfg(all(feature = "games", feature = "serde"))]
+    Eco(&'a crate::games::eco::Response),
 }
 
 /// All player types
@@ -68,6 +72,8 @@ pub enum GenericPlayer<'a> {
     TheShip(&'a crate::games::theship::TheShipPlayer),
     #[cfg(feature = "games")]
     JCMP2(&'a crate::games::jc2m::Player),
+    #[cfg(all(feature = "games", feature = "serde"))]
+    Eco(&'a crate::games::eco::Player),
 }
 
 pub trait CommonResponse {

--- a/crates/lib/src/protocols/types.rs
+++ b/crates/lib/src/protocols/types.rs
@@ -19,7 +19,6 @@ pub enum ProprietaryProtocol {
     FFOW,
     JC2M,
     Savage2,
-    #[cfg(feature = "serde")]
     Eco,
 }
 
@@ -53,7 +52,7 @@ pub enum GenericResponse<'a> {
     JC2M(&'a crate::games::jc2m::Response),
     #[cfg(feature = "games")]
     Savage2(&'a crate::games::savage2::Response),
-    #[cfg(all(feature = "games", feature = "serde"))]
+    #[cfg(feature = "games")]
     Eco(&'a crate::games::eco::Response),
 }
 
@@ -72,7 +71,7 @@ pub enum GenericPlayer<'a> {
     TheShip(&'a crate::games::theship::TheShipPlayer),
     #[cfg(feature = "games")]
     JCMP2(&'a crate::games::jc2m::Player),
-    #[cfg(all(feature = "games", feature = "serde"))]
+    #[cfg(feature = "games")]
     Eco(&'a crate::games::eco::Player),
 }
 


### PR DESCRIPTION
A lot of games that have a proprietary protocol hosts their query capabilities via a simple http server, on a GET query.

In this (unfinished, concept) PR, I have attempted on adding [Eco](https://store.steampowered.com/app/382310/Eco/), a game that provides its query information on its ip and port (+1 for query) and `/frontpage`, resulting in `http://{ip}:{port}/frontpage`.

I added HTTP support via [Reqwest](https://github.com/seanmonstar/reqwest), as I find it easy to use and provides a blocking API (supports async for future use). 
I thought initially on using [Hyper](https://github.com/hyperium/hyper), but I find it quite complicated compared to Reqwest.

Some caviats:
* Reqwest doesn't support separate read and write timeouts, they group these 2 as one timeout setting.
* * I for one find this to be understandable, I personally never encountered a situation where I needed separate timeouts for these and would suggest doing the same for the socket timeouts.
* `serde_derive` dependency, as almost all http queries return json data, we need structs with the `Deserialize` derive. [**EDIT**: we could leave it as is now and think about this later on]
* * We could go around this, just collect data as `HashMap<String, String>` then parse every field, sounds alright to me but I'm not really sure on it (how manageable would this be).
* [Mentioned by @Douile]: How do we set if the HTTP request is secured?
* * (Some possible solutions in my first comment)

Open to talk about possibilities and problems on this, as it's something that'll be used a lot.