### PR TITLE
fix(test): node gid test

### DIFF
--- a/crates/lib/tests/game_ids.rs
+++ b/crates/lib/tests/game_ids.rs
@@ -395,7 +395,7 @@ fn check_definitions_match_name_rules() {
 fn check_node_definitions_match_name_rules() {
     let mut file = fs::OpenOptions::new()
         .read(true)
-        .open("./node-gamedig/games.txt")
+        .open("GAMES_LIST.md")
         .unwrap();
 
     let mut text = String::new();
@@ -403,12 +403,12 @@ fn check_node_definitions_match_name_rules() {
 
     let games = text
         .split('\n')
-        .map(|line| line.trim())
-        .filter(|line| !line.starts_with('#') && !line.is_empty())
+        .filter(|line| line.starts_with("| "))
+        .skip(1) // the header
         .filter_map(|line| {
-            let parts: Vec<_> = line.splitn(3, '|').collect();
-            if parts.len() > 1 {
-                Some((parts[0].split(',').next().unwrap(), parts[1]))
+            let parts: Vec<_> = line.splitn(4, '|').collect();
+            if parts.len() > 3 {
+                Some((parts[1].trim(), parts[2].trim()))
             } else {
                 None
             }


### PR DESCRIPTION
Fixes the node gid extraction that was made before the [Node-GameDig#407](https://github.com/gamedig/node-gamedig/pull/407) merge (that removed `games.txt` and provided an in-code substitute), this test now processes the `GAMES_LIST.md` file (not sure if this is the best solution but its easier than the JS file).

This PR also moves the test file into the lib, i couldn't run it beforehand (???).