### PR TITLE
fix: various crate/clippy/ci changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,49 +6,49 @@ repos:
       - id: clippy
         name: Check clippy
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: rustup run --install nightly-2023-07-09 cargo-clippy -- --workspace --all-features -- -D warnings
 
       - id: build-no-features
         name: Check crate build with no features
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: cargo check --workspace --no-default-features
 
       - id: build-all-features
         name: Check crate builds with all features
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: cargo check --workspace --all-features --lib --bins --examples
 
       - id: test
         name: Check tests pass
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: cargo test --workspace --bins --lib --examples --tests --all-features
 
       - id: format
         name: Check rustfmt
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: rustup run --install nightly-2023-07-09 cargo-fmt --check
 
       - id: msrv
         name: Check MSRV compiles (lib only)
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: rustup run --install 1.65 cargo check -p gamedig
 
       - id: docs
         name: Check rustdoc compiles
         language: system
-        files: '[.]rs$'
+        files: '([.]rs|Cargo\.toml)$'
         pass_filenames: false
         entry: env RUSTDOCFLAGS="-D warnings" cargo doc
         

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,6 +7,7 @@ description = "A command line interface for gamedig"
 license = "MIT"
 version = "0.4.1"
 edition = "2021"
+default-run = "gamedig-cli"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/id-tests/src/lib.rs
+++ b/crates/id-tests/src/lib.rs
@@ -150,8 +150,8 @@ pub fn test_game_name_rule(
         let mut game_names_same = other_game_name_words.len() == game.words.len();
         // Check all words in game name are the same
         if game_names_same {
-            for i in 0 .. game.words.len() {
-                if game.words[i].to_lowercase() != other_game_name_words[i].to_lowercase() {
+            for (our_word, their_word) in game.words.iter().zip(other_game_name_words.iter()) {
+                if our_word.to_lowercase() != their_word.to_lowercase() {
                     game_names_same = false;
                     break;
                 }

--- a/crates/id-tests/src/main.rs
+++ b/crates/id-tests/src/main.rs
@@ -13,7 +13,7 @@ struct Game {
 use gamedig_id_tests::test_game_name_rules;
 
 fn main() {
-    let games: GamesInput = if let Some(file) = std::env::args_os().skip(1).next() {
+    let games: GamesInput = if let Some(file) = std::env::args_os().nth(1) {
         let file = std::fs::OpenOptions::new().read(true).open(file).unwrap();
 
         serde_json::from_reader(file).unwrap()

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -38,7 +38,7 @@ phf = { version = "0.11", optional = true, features = ["macros"] }
 clap = { version = "4.1.11", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-gamedig-id-tests = { path = "../id-tests", no-default-features = true }
+gamedig-id-tests = { path = "../id-tests", default-features = false }
 
 # Examples
 [[example]]


### PR DESCRIPTION
- Set default binary to gamedig cli so that `cargo run` runs the CLI.
- Use the correct option to disable default features when depending on gamedig-id-tests
- Run pre-commit CI when Cargo.toml gets changed
- Clippy fixes in ID test library