### PR TITLE
feat: add Chivarly: Medieval Warfare support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Games:
 - [Mindustry](https://mindustrygame.github.io/) support.
 - Eco support (by @CosminPerRam).
 - [Call Of Duty: Black Ops 3](https://store.steampowered.com/agecheck/app/311210/) support.
+- [Chivalry: Medieval Warfare](https://store.steampowered.com/app/219640/Chivalry_Medieval_Warfare/) support
 
 Crate:
 - Changed the serde feature to only enable serde derive for some types: serde and serde_json is now a dependecy by default.

--- a/GAMES.md
+++ b/GAMES.md
@@ -80,6 +80,7 @@ Beware of the `Notes` column, as it contains information about query port offset
 | Base Defense                       | BASEDEFENSE         | Valve                | Query port: 27015. Does not respond to the rules query.                                                                                                                   |
 | Zombie Panic: Source               | ZPS                 | Valve                | Query port: 27015.                                                                                                                                                        |
 | Call Of Duty: Black Ops 3          | CODBO3              | Valve                | Query port: 27017.                                                                                                                                                        |
+| Chivalry: Medieval Warfare         | CMW                 | Valve                | Query port offset: 2                                                                                                                                                      |
 
 ## Planned to add support:
 _

--- a/crates/lib/src/games/definitions.rs
+++ b/crates/lib/src/games/definitions.rs
@@ -74,6 +74,7 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "cscz" => game!("Counter Strike: Condition Zero", 27015, Protocol::Valve(Engine::new_gold_src(false))),
     "csgo" => game!("Counter-Strike: Global Offensive", 27015, Protocol::Valve(Engine::new(730))),
     "css" => game!("Counter-Strike: Source", 27015, Protocol::Valve(Engine::new(240))),
+    "cmw" => game!("Chivalry: Medieval Warfare", 7779, Protocol::Valve(Engine::new(219_640))),
     "creativerse" => game!("Creativerse", 26901, Protocol::Valve(Engine::new(280_790))),
     "crysiswars" => game!("Crysis Wars", 64100, Protocol::Gamespy(GameSpyVersion::Three)),
     "dod" => game!("Day of Defeat", 27015, Protocol::Valve(Engine::new_gold_src(false))),

--- a/crates/lib/src/games/valve.rs
+++ b/crates/lib/src/games/valve.rs
@@ -46,6 +46,7 @@ game_query_mod!(
     Engine::new(311_210),
     27017
 );
+game_query_mod!(cmw, "Chivalry: Medieval Warfare", Engine::new(219_640), 7779);
 game_query_mod!(codenamecure, "Codename CURE", Engine::new(355_180), 27015);
 game_query_mod!(
     colonysurvival,


### PR DESCRIPTION
Adds [Chivalry: Medieval Warfare](https://store.steampowered.com/app/219640/Chivalry_Medieval_Warfare/) support.

The problem is that the query is not successful, while trying to query servers all of them fail at parsing strings: 
![image](https://github.com/gamedig/rust-gamedig/assets/7972857/cca8e008-1eb7-4cd0-a44d-e6c6999f5fc9)
Note that `Buffer 347`:
![image](https://github.com/gamedig/rust-gamedig/assets/7972857/8fd158e8-34f4-4713-bd50-c31d6916ef22)
If I'm changing `std::str::from_utf8` with `String::from_utf8_lossy` all queries work and are as expected.