### PR TITLE
feat: add Soulmask support

### DIFF
--- a/GAMES.md
+++ b/GAMES.md
@@ -94,6 +94,7 @@ requirements/information.
 | Arma Reforger                      | ARMAREFORGER        | Valve                |                                                                                                                                                                           |
 | Nova-Life: Amboise                 | NLA                 | Valve                |                                                                                                                                                                           |
 | Abiotic Factor                     | ABIOTICFACTOR       | Valve                |                                                                                                                                                                           |
+| Soulmask                           | SOULMASK            | Valve                |                                                                                                                                                                           |
 
 ## Planned to add support:
 

--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -2,7 +2,9 @@ Who knows what the future holds...
 
 # 0.X.Y - DD/MM/YYYY
 
-To be made...
+Games:
+
+- [Soulmask](https://store.steampowered.com/app/2646460/Soulmask/) support.
 
 # 0.5.1 - 12/05/2024
 

--- a/crates/lib/src/games/definitions.rs
+++ b/crates/lib/src/games/definitions.rs
@@ -124,6 +124,7 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "sco" => game!("Sven Co-op", 27015, Protocol::Valve(Engine::new_gold_src(false))),
     "sdtd" => game!("7 Days to Die", 26900, Protocol::Valve(Engine::new(251_570))),
     "sof2" => game!("Soldier of Fortune 2", 20100, Protocol::Quake(QuakeVersion::Three)),
+    "soulmask" => game!("Soulmask", 27015, Protocol::Valve(Engine::new(2_646_460))),
     "serioussam" => game!("Serious Sam", 25601, Protocol::Gamespy(GameSpyVersion::One)),
     "squad" => game!("Squad", 27165, Protocol::Valve(Engine::new(393_380))),
     "theforest" => game!("The Forest", 27016, Protocol::Valve(Engine::new(556_450))),

--- a/crates/lib/src/games/valve.rs
+++ b/crates/lib/src/games/valve.rs
@@ -152,6 +152,7 @@ game_query_mod!(ror2, "Risk of Rain 2", Engine::new(632_360), 27016);
 game_query_mod!(rust, "Rust", Engine::new(252_490), 27015);
 game_query_mod!(sco, "Sven Co-op", Engine::new_gold_src(false), 27015);
 game_query_mod!(sdtd, "7 Days to Die", Engine::new(251_570), 26900);
+game_query_mod!(soulmask, "Soulmask", Engine::new(2_646_460), 27015);
 game_query_mod!(squad, "Squad", Engine::new(393_380), 27165);
 game_query_mod!(teamfortress2, "Team Fortress 2", Engine::new(440), 27015);
 game_query_mod!(


### PR DESCRIPTION
Yet another Valve-protocol game, Soulmask, [added in Node-GameDig](https://github.com/gamedig/node-gamedig/pull/572) by @xCausxn.