### PR TITLE
Fix CLI release profile

### DIFF
--- a/crates/cli/.cargo/config.toml
+++ b/crates/cli/.cargo/config.toml
@@ -1,0 +1,10 @@
+[profile.release]
+opt-level = 'z'
+debug = false
+rpath = true
+lto = 'fat'
+codegen-units = 1
+strip = 'debuginfo'
+
+[profile.release.package."*"]
+opt-level = 'z'


### PR DESCRIPTION
This PR adds an explicit configuration for the CLI crate to optimize release builds within the CI pipeline.

Unsure if this is worthy of a patch, I think its okay for now it can just be included in next release when built by CI.