### PR TITLE
Fix: read string may panic index out of range

### DIFF
--- a/crates/lib/src/buffer.rs
+++ b/crates/lib/src/buffer.rs
@@ -146,10 +146,10 @@ impl<'a, B: ByteOrder> Buffer<'a, B> {
     /// Returns a `BufferError` if there is an error decoding the string.
     pub fn read_string<D: StringDecoder>(&mut self, until: Option<D::Delimiter>) -> GDResult<String> {
         // Check if the cursor is out of bounds.
-        if self.cursor > self.remaining_length() {
+        if self.cursor > self.data_length() {
             return Err(PacketUnderflow.context(format!(
                 "Cursor position {} is out of bounds when reading string. Buffer length: {}",
-                self.cursor, self.data.len()
+                self.cursor, self.data_length()
             )));
         }
 

--- a/crates/lib/src/buffer.rs
+++ b/crates/lib/src/buffer.rs
@@ -146,11 +146,10 @@ impl<'a, B: ByteOrder> Buffer<'a, B> {
     /// Returns a `BufferError` if there is an error decoding the string.
     pub fn read_string<D: StringDecoder>(&mut self, until: Option<D::Delimiter>) -> GDResult<String> {
         // Check if the cursor is out of bounds.
-        let remaining = self.remaining_length();
-        if self.cursor > remaining {
+        if self.cursor > self.remaining_length() {
             return Err(PacketUnderflow.context(format!(
-                "Cursor position {} is out of bounds when reading string. Remaining bytes: {remaining}",
-                self.cursor
+                "Cursor position {} is out of bounds when reading string. Buffer length: {}",
+                self.cursor, self.data.len()
             )));
         }
 

--- a/crates/lib/src/buffer.rs
+++ b/crates/lib/src/buffer.rs
@@ -149,7 +149,8 @@ impl<'a, B: ByteOrder> Buffer<'a, B> {
         if self.cursor > self.data_length() {
             return Err(PacketUnderflow.context(format!(
                 "Cursor position {} is out of bounds when reading string. Buffer length: {}",
-                self.cursor, self.data_length()
+                self.cursor,
+                self.data_length()
             )));
         }
 

--- a/crates/lib/src/buffer.rs
+++ b/crates/lib/src/buffer.rs
@@ -145,6 +145,15 @@ impl<'a, B: ByteOrder> Buffer<'a, B> {
     ///
     /// Returns a `BufferError` if there is an error decoding the string.
     pub fn read_string<D: StringDecoder>(&mut self, until: Option<D::Delimiter>) -> GDResult<String> {
+        // Check if the cursor is out of bounds.
+        let remaining = self.remaining_length();
+        if self.cursor > remaining {
+            return Err(PacketUnderflow.context(format!(
+                "Cursor position {} is out of bounds when reading string. Remaining bytes: {remaining}",
+                self.cursor
+            )));
+        }
+
         // Slice the data array from the current cursor position to the end.
         let data_slice = &self.data[self.cursor ..];
 


### PR DESCRIPTION
Adds a out of bounds check and error handling on read string within buffer to handle a panic that may occur.