### PR TITLE
Fix: try to match port on epic protocol

### DIFF
--- a/crates/lib/src/protocols/epic/protocol.rs
+++ b/crates/lib/src/protocols/epic/protocol.rs
@@ -118,8 +118,6 @@ impl EpicProtocol {
                 return Err(PacketBad.context("No servers provided."));
             }
 
-            let mut fallback_session: Option<Value> = None;
-
             for session in sessions.into_iter() {
                 let attributes = session
                     .get("attributes")
@@ -137,20 +135,9 @@ impl EpicProtocol {
                     .and_then(Value::as_u64)
                     .map_or(false, |v| v == port as u64);
 
-                // Prioritize exact match of both address and port
                 if address_match && port_match {
                     return Ok(session);
                 }
-
-                // Store session that matches either the address or port
-                if address_match || port_match {
-                    fallback_session = Some(session);
-                }
-            }
-
-            // If no exact match, return the fallback session if available
-            if let Some(fallback) = fallback_session {
-                return Ok(fallback);
             }
 
             return Err(

--- a/crates/lib/src/protocols/epic/protocol.rs
+++ b/crates/lib/src/protocols/epic/protocol.rs
@@ -123,19 +123,12 @@ impl EpicProtocol {
                     .get("attributes")
                     .ok_or(PacketBad.context("Expected attributes field missing in sessions."))?;
 
-                let address_match = attributes
+                let full_address_match = attributes
                     .get("ADDRESSBOUND_s")
                     .and_then(Value::as_str)
-                    .map_or(false, |v| {
-                        v == format!("0.0.0.0:{}", port) || v == format!("{}:{}", address, port)
-                    });
+                    .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port));
 
-                let port_match = attributes
-                    .get("GAMESERVER_PORT_l")
-                    .and_then(Value::as_u64)
-                    .map_or(false, |v| v == port as u64);
-
-                if address_match && port_match {
+                if full_address_match {
                     return Ok(session);
                 }
             }

--- a/crates/lib/src/protocols/epic/protocol.rs
+++ b/crates/lib/src/protocols/epic/protocol.rs
@@ -118,6 +118,8 @@ impl EpicProtocol {
                 return Err(PacketBad.context("No servers provided."));
             }
 
+            let mut fallback_session: Option<Value> = None;
+
             for session in sessions.into_iter() {
                 let attributes = session
                     .get("attributes")
@@ -135,10 +137,20 @@ impl EpicProtocol {
                     .and_then(Value::as_u64)
                     .map_or(false, |v| v == port as u64);
 
-                // If either address or port matches, return the session
-                if address_match || port_match {
+                // Prioritize exact match of both address and port
+                if address_match && port_match {
                     return Ok(session);
                 }
+
+                // Store session that matches either the address or port
+                if address_match || port_match {
+                    fallback_session = Some(session);
+                }
+            }
+
+            // If no exact match, return the fallback session if available
+            if let Some(fallback) = fallback_session {
+                return Ok(fallback);
             }
 
             return Err(

--- a/crates/lib/src/protocols/epic/protocol.rs
+++ b/crates/lib/src/protocols/epic/protocol.rs
@@ -123,12 +123,16 @@ impl EpicProtocol {
                     .get("attributes")
                     .ok_or(PacketBad.context("Expected attributes field missing in sessions."))?;
 
-                let full_address_match = attributes
+                let address_match = attributes
                     .get("ADDRESSBOUND_s")
                     .and_then(Value::as_str)
-                    .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port));
+                    .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port))
+                    || attributes
+                        .get("ADDRESS_s")
+                        .and_then(Value::as_str)
+                        .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port));
 
-                if full_address_match {
+                if address_match {
                     return Ok(session);
                 }
             }

--- a/crates/lib/src/protocols/epic/protocol.rs
+++ b/crates/lib/src/protocols/epic/protocol.rs
@@ -128,10 +128,6 @@ impl EpicProtocol {
                     .and_then(Value::as_str)
                     .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port))
                     || attributes
-                        .get("ADDRESS_s")
-                        .and_then(Value::as_str)
-                        .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port))
-                    || attributes
                         .get("GAMESERVER_PORT_1")
                         .and_then(Value::as_u64)
                         .map_or(false, |v| v == port as u64);

--- a/crates/lib/src/protocols/epic/protocol.rs
+++ b/crates/lib/src/protocols/epic/protocol.rs
@@ -130,7 +130,11 @@ impl EpicProtocol {
                     || attributes
                         .get("ADDRESS_s")
                         .and_then(Value::as_str)
-                        .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port));
+                        .map_or(false, |v| v == address || v == format!("0.0.0.0:{}", port))
+                    || attributes
+                        .get("GAMESERVER_PORT_1")
+                        .and_then(Value::as_u64)
+                        .map_or(false, |v| v == port as u64);
 
                 if address_match {
                     return Ok(session);


### PR DESCRIPTION
This follows the same method as node to try and match ports on epic query's.