### PR TITLE
ci: fix audit failing by generating cargo lock file before running it

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Generate Cargo.lock # https://github.com/rustsec/audit-check/issues/27
+        run: cargo generate-lockfile
+
+      - name: Audit Check
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/gamedig/rust-gamedig/pull/227 fails to get through because of audit check v2 which [removed the auto generation of it](https://github.com/rustsec/audit-check/pull/20), this is [intended](https://github.com/rustsec/audit-check/issues/27).