### PR TITLE
Add Starbound support

### DIFF
--- a/crates/lib/src/games/definitions.rs
+++ b/crates/lib/src/games/definitions.rs
@@ -124,6 +124,11 @@ pub static GAMES: Map<&'static str, Game> = phf_map! {
     "soulmask" => game!("Soulmask", 27015, Protocol::Valve(Engine::new(2_646_460))),
     "serioussam" => game!("Serious Sam", 25601, Protocol::Gamespy(GameSpyVersion::One)),
     "squad" => game!("Squad", 27165, Protocol::Valve(Engine::new(393_380))),
+    "starbound" => game!("Starbound", 21025, Protocol::Valve(Engine::new(211_820)), GatheringSettings {
+        players: GatherToggle::Enforce,
+        rules: GatherToggle::Enforce,
+        check_app_id: false,
+    }.into_extra()),
     "theforest" => game!("The Forest", 27016, Protocol::Valve(Engine::new_with_dedicated(242_760, 556_450))),
     "thefront" => game!("The Front", 27015, Protocol::Valve(Engine::new(2_285_150))),
     "teamfortress2" => game!("Team Fortress 2", 27015, Protocol::Valve(Engine::new(440))),

--- a/crates/lib/src/games/valve.rs
+++ b/crates/lib/src/games/valve.rs
@@ -154,6 +154,17 @@ game_query_mod!(sco, "Sven Co-op", Engine::new_gold_src(false), 27015);
 game_query_mod!(sdtd, "7 Days to Die", Engine::new(251_570), 26900);
 game_query_mod!(soulmask, "Soulmask", Engine::new(2_646_460), 27015);
 game_query_mod!(squad, "Squad", Engine::new(393_380), 27165);
+game_query_mod!(
+    starbound,
+    "Starbound",
+    Engine::new(211_820),
+    21025,
+    GatheringSettings {
+        players: GatherToggle::Enforce,
+        rules: GatherToggle::Enforce,
+        check_app_id: false,
+    }
+);
 game_query_mod!(teamfortress2, "Team Fortress 2", Engine::new(440), 27015);
 game_query_mod!(
     tfc,

--- a/crates/lib/src/protocols/valve/types.rs
+++ b/crates/lib/src/protocols/valve/types.rs
@@ -19,7 +19,7 @@ pub enum Server {
 
 impl Server {
     pub(crate) fn from_gldsrc(value: u8) -> GDResult<Self> {
-        Ok(match value {
+        Ok(match value.to_ascii_lowercase() {
             100 => Self::Dedicated,    //'d'
             108 => Self::NonDedicated, //'l'
             112 => Self::TV,           //'p'
@@ -39,7 +39,7 @@ pub enum Environment {
 
 impl Environment {
     pub(crate) fn from_gldsrc(value: u8) -> GDResult<Self> {
-        Ok(match value {
+        Ok(match value.to_ascii_lowercase() {
             108 => Self::Linux,     //'l'
             119 => Self::Windows,   //'w'
             109 | 111 => Self::Mac, //'m' or 'o'


### PR DESCRIPTION
for some reason Starbound returns the server type and environment in uppercase, so I'm converting to lowercase to work around that.