### PR TITLE
Added Python support for Minecraft

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -58,6 +58,8 @@ pcap-file = { version = "2.0", optional = true }
 pnet_packet = { version = "0.35", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
+pyo3 = { version = "0.20", features = ["extension-module"] }
+
 [dev-dependencies]
 gamedig-id-tests = { path = "../id-tests", default-features = false }
 

--- a/crates/lib/src/games/minecraft/mod.rs
+++ b/crates/lib/src/games/minecraft/mod.rs
@@ -13,6 +13,12 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use std::net::{IpAddr, SocketAddr};
 
+#[pymodule]
+pub fn minecraft(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(py_query, m)?)?;
+    Ok(())
+}
+
 /// Query with all the protocol variants one by one (Java -> Bedrock -> Legacy
 /// (1.6 -> 1.4 -> Beta 1.8)).
 pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {

--- a/crates/lib/src/games/minecraft/mod.rs
+++ b/crates/lib/src/games/minecraft/mod.rs
@@ -8,11 +8,20 @@ pub mod types;
 pub use protocol::*;
 pub use types::*;
 
-use crate::{GDErrorKind, GDResult};
+use crate::{utils::convert_to_pydict, GDErrorKind, GDResult};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::PyDict;
 use std::net::{IpAddr, SocketAddr};
 
+/// The Minecraft package for the gamedig Python library.
+///
+/// # Example:
+/// ```python
+/// import gamedig
+///
+/// # Query a Minecraft server
+/// response = gamedig.minecraft.py_query("127.0.0.1", 25565)
+/// ```
 #[pymodule]
 pub fn minecraft(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_query, m)?)?;
@@ -37,48 +46,35 @@ pub fn query(address: &IpAddr, port: Option<u16>) -> GDResult<JavaResponse> {
     Err(GDErrorKind::AutoQuery.into())
 }
 
+/// Query a Minecraft server.
+///
+/// # Parameters:
+/// - address: str
+/// - port: int
+///
+/// # Returns:
+/// - dict: The server response.
+///
+/// # Example:
+/// ```python
+/// import gamedig
+///
+/// # Query a Minecraft server
+/// response = gamedig.minecraft.py_query("
 #[pyfunction]
 pub fn py_query(address: &str, port: u16) -> PyResult<Py<PyDict>> {
     let response = query(&address.parse().unwrap(), Some(port));
-    // None is the default port (which is 27015), could also be Some(27015)
 
-    match response { // Result type, must check what it is...
+    match response {
         Err(error) => {
             println!("Couldn't query, error: {}", error);
             Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("Couldn't query, error: {}", error)))
         },
         Ok(r) => {
-            Python::with_gil(|py| {
-                let dict = PyDict::new(py);
-
-                dict.set_item("game_version", r.game_version)?;
-                dict.set_item("protocol_version", r.protocol_version)?;
-                dict.set_item("players_maximum", r.players_maximum)?;
-                dict.set_item("players_online", r.players_online)?;
-                dict.set_item("description", r.description)?;
-                dict.set_item("favicon", r.favicon)?;
-                dict.set_item("previews_chat", r.previews_chat)?;
-                dict.set_item("enforces_secure_chat", r.enforces_secure_chat)?;
-                dict.set_item("server_type", format!("{:?}", r.server_type))?;
-
-                if let Some(players) = r.players {
-                    let players_list = PyList::new(py, players.iter().map(|p| {
-                        let player_dict = PyDict::new(py);
-                        player_dict.set_item("name", &p.name).unwrap();
-                        player_dict.set_item("id", &p.id).unwrap();
-                        player_dict
-                    }).collect::<Vec<_>>());
-                    dict.set_item("players", players_list)?;
-                } else {
-                    dict.set_item("players", py.None())?;
-                }
-
-                Ok(dict.into_py(py))
-            })
+            Python::with_gil(|py| convert_to_pydict(py, &r))
         }
     }
 }
-
 
 /// Query a Java Server.
 pub fn query_java(

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -63,3 +63,5 @@ pub use services::*;
 
 // Re-export types needed to call games::query::query in the root
 pub use protocols::types::{ExtraRequestSettings, TimeoutSettings};
+
+pub mod python;

--- a/crates/lib/src/python.rs
+++ b/crates/lib/src/python.rs
@@ -4,6 +4,10 @@ use crate::games;
 
 #[pymodule]
 fn gamedig(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(games::minecraft::py_query, m)?)?;
+    // Add the game modules.
+    let module = PyModule::new(_py, "minecraft")?;
+    games::minecraft::minecraft(_py, module)?;
+    m.add_submodule(module)?;
+
     Ok(())
 }

--- a/crates/lib/src/python.rs
+++ b/crates/lib/src/python.rs
@@ -1,0 +1,9 @@
+use pyo3::{prelude::*, types::PyModule};
+
+use crate::games;
+
+#[pymodule]
+fn gamedig(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(games::minecraft::py_query, m)?)?;
+    Ok(())
+}

--- a/crates/lib/src/utils.rs
+++ b/crates/lib/src/utils.rs
@@ -1,6 +1,8 @@
 use crate::GDErrorKind::{PacketOverflow, PacketReceive, PacketSend, PacketUnderflow};
 use crate::GDResult;
 use std::cmp::Ordering;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 pub fn error_by_expected_size(expected: usize, size: usize) -> GDResult<()> {
     match size.cmp(&expected) {
@@ -27,6 +29,14 @@ pub fn retry_on_timeout<T>(mut retry_count: usize, mut fetch: impl FnMut() -> GD
         retry_count -= 1;
     }
     Err(last_err)
+}
+
+pub trait ToPyDict {
+    fn to_pydict(&self, py: Python) -> PyResult<Py<PyDict>>;
+}
+
+pub fn convert_to_pydict<T: ToPyDict>(py: Python, value: &T) -> PyResult<Py<PyDict>> {
+    value.to_pydict(py)
 }
 
 /// Run gather_fn based on the value of gather_toggle.


### PR DESCRIPTION
I've written up a simple concept PR to showcase how easy adding Python support would be.

Here is some sample output:
```
Python 3.9.2 (default, Dec  1 2024, 12:12:57) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gamedig
>>> gamedig.py_query
<built-in function py_query>
>>> gamedig.py_query("10.152.183.26", 25565)
{'game_version': '1.21.4', 'protocol_version': 769, 'players_maximum': 20, 'players_online': 0, 'description': '"Welcome to Minecraft on Kubernetes!"', 'favicon': None, 'previews_chat': None, 'enforces_secure_chat': True, 'server_type': 'Java', 'players': None}
>>> gamedig.py_query("10.152.183.26", 25565)
{'game_version': '1.21.4', 'protocol_version': 769, 'players_maximum': 20, 'players_online': 1, 'description': '"Welcome to Minecraft on Kubernetes!"', 'favicon': None, 'previews_chat': None, 'enforces_secure_chat': True, 'server_type': 'Java', 'players': [{'name': 'fossum99', 'id': '2fe85555-5555-5555-5555-986b061d5555'}]}
>>> 
```